### PR TITLE
feat: HTTP-Only Cookies fix + frontend auth flag

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,7 +6,28 @@ const API_BASE =
     ? process.env.NEXT_PUBLIC_API_URL.replace(/\/$/, "")
     : "";
 
+
+export function setAuthFlag() {
+  if (typeof window !== "undefined") {
+    localStorage.setItem("is_logged_in", "true");
+  }
+}
+
+export function clearAuthFlag() {
+  if (typeof window !== "undefined") {
+    localStorage.removeItem("is_logged_in");
+  }
+}
+
+export function hasAuthFlag(): boolean {
+  if (typeof window !== "undefined") {
+    return localStorage.getItem("is_logged_in") === "true";
+  }
+  return false;
+}
+
 export function clearTokens() {
+  clearAuthFlag();
   // Deprecated: No longer used for localStorage, backend handles HttpOnly cookies.
 }
 
@@ -53,6 +74,9 @@ async function apiFetch(
 }
 
 export const api = {
+  hasAuthFlag,
+  setAuthFlag,
+  clearAuthFlag,
   clearTokens,
 
   async login(email: string, password: string) {
@@ -64,6 +88,7 @@ export const api = {
     });
     if (!res.ok) throw new Error((await res.json()).detail || "Login failed");
     const data = await res.json();
+    if (!data.requires_2fa) setAuthFlag();
     
     return data;
   },
@@ -77,7 +102,7 @@ export const api = {
     });
     if (!res.ok) throw new Error((await res.json()).detail || "2FA verification failed");
     const tokens: TokenPair = await res.json();
-    
+    setAuthFlag();
     return tokens;
   },
 
@@ -90,7 +115,7 @@ export const api = {
     });
     if (!res.ok) throw new Error((await res.json()).detail || "Recovery code verification failed");
     const tokens: TokenPair = await res.json();
-    
+    setAuthFlag();
     return tokens;
   },
 
@@ -132,6 +157,7 @@ export const api = {
     });
     if (!res.ok)
       throw new Error((await res.json()).detail || "Registration failed");
+    setAuthFlag();
     return res.json();
   },
 
@@ -347,7 +373,7 @@ export const api = {
     async deleteAccount() {
     const res = await apiFetch("/api/v1/auth/me", { method: "DELETE" });
     if (!res.ok) throw new Error("Failed to delete account");
-    clearTokens();
+    clearAuthFlag();
   },
 
   async logout() {
@@ -360,7 +386,7 @@ export const api = {
     } catch (e) {
       console.error("Logout failed:", e);
     }
-    clearTokens();
+    clearAuthFlag();
   },
 
   async getVehicles() {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -350,7 +350,16 @@ export const api = {
     clearTokens();
   },
 
-  logout() {
+  async logout() {
+    try {
+      await fetch(`${API_BASE}/api/v1/auth/logout`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+      });
+    } catch (e) {
+      console.error("Logout failed:", e);
+    }
     clearTokens();
   },
 

--- a/frontend/src/lib/auth-context.tsx
+++ b/frontend/src/lib/auth-context.tsx
@@ -46,8 +46,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     try {
       const me = await api.getMe();
       setUser(me);
-    } catch {
+    } catch (err: any) {
       setUser(null);
+      if (err.message === "Not authenticated") {
+        api.clearTokens();
+      }
     } finally {
       setLoading(false);
     }

--- a/frontend/src/lib/auth-context.tsx
+++ b/frontend/src/lib/auth-context.tsx
@@ -44,16 +44,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const refreshUser = useCallback(async () => {
     try {
-      const tokens = api.getTokens();
-      if (!tokens?.access_token) {
-        setUser(null);
-        return;
-      }
       const me = await api.getMe();
       setUser(me);
     } catch {
       setUser(null);
-      api.clearTokens();
     } finally {
       setLoading(false);
     }

--- a/frontend/src/lib/auth-context.tsx
+++ b/frontend/src/lib/auth-context.tsx
@@ -31,7 +31,7 @@ interface AuthContextType {
     displayName?: string,
     inviteToken?: string
   ) => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
   refreshUser: () => Promise<void>;
 }
 
@@ -94,8 +94,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     router.push("/");
   };
 
-  const logout = () => {
-    api.logout();
+  const logout = async () => {
+    await api.logout();
     setUser(null);
     router.push("/login");
   };

--- a/frontend/src/lib/auth-context.tsx
+++ b/frontend/src/lib/auth-context.tsx
@@ -43,13 +43,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const router = useRouter();
 
   const refreshUser = useCallback(async () => {
+    if (!api.hasAuthFlag()) {
+      setUser(null);
+      setLoading(false);
+      return;
+    }
+    
     try {
       const me = await api.getMe();
       setUser(me);
     } catch (err: any) {
       setUser(null);
       if (err.message === "Not authenticated") {
-        api.clearTokens();
+        api.clearAuthFlag();
       }
     } finally {
       setLoading(false);


### PR DESCRIPTION
## 📋 Summary

This PR addresses two critical edge cases discovered during QA testing of the HTTP-Only cookie migration:
1. **Unnecessary Console Errors:** Unauthenticated users hitting the dashboard would trigger a `getMe` call, which returned 401, subsequently triggering a `refresh` call that also returned 401. This has been resolved by properly clearing the tokens in context and breaking the loop.
2. **Broken Logout:** The `logout` function on the frontend was still using the old `clearTokens` logic (which deleted `localStorage`) but failed to call the backend `/api/v1/auth/logout` endpoint. Because of this, the `HttpOnly` cookies were never actually deleted from the browser, allowing users to manually navigate back to the dashboard after logging out. This PR wires the frontend `logout` function to explicitly call the backend to delete the cookies.

**Related Issues:** Closes Auth Hotfix Requirement

---

## 🧩 Type of Change

- [ ] 🆕 New feature (e.g. new dashboard, API endpoint)
- [x] 🐛 Bug fix
- [ ] ⚙️ Backend change (API, collector, database)
- [x] 🎨 Frontend change (UI, charts, pages)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

- [x] Backend runs and tests pass (if applicable)
- [x] Frontend builds (`npm run build` in `frontend/`)
- [x] Manual testing done (if applicable)

---

## 👥 Reviewer Notes

Please verify that clicking "Sign Out" successfully invalidates the session and that manual navigation back to `/` returns you to the login screen.

---

## 📌 Additional Context

N/A
