### PR TITLE
fix(stats): implement live incremental updates for daily driving and charging stats

### DIFF
--- a/backend/app/api/v1/vehicles.py
+++ b/backend/app/api/v1/vehicles.py
@@ -1213,7 +1213,7 @@ async def get_statistics(
         trip_where.append(Trip.start_date >= from_date)
     if to_date:
         trip_where.append(Trip.start_date <= to_date)
-    time_driven_expr = func.sum(case((Trip.end_date.isnot(None), func.extract("epoch", Trip.end_date - Trip.start_date)), else_=0,))
+    time_driven_expr = func.sum(case((Trip.end_date.isnot(None), func.extract("epoch", Trip.end_date - Trip.start_date)), else_=func.extract("epoch", func.now() - Trip.start_date),))
     median_expr = func.percentile_cont(0.5).within_group((Trip.end_odometer - Trip.start_odometer).asc()).label("median_distance")
     stmt_trip = (
         select(
@@ -1237,7 +1237,7 @@ async def get_statistics(
         charge_where.append(ChargingSession.session_start >= from_date)
     if to_date:
         charge_where.append(ChargingSession.session_start <= to_date)
-    time_charging_expr = func.sum(func.extract("epoch", func.coalesce(ChargingSession.session_end, ChargingSession.session_start) - ChargingSession.session_start,))
+    time_charging_expr = func.sum(func.extract("epoch", func.coalesce(ChargingSession.session_end, func.now()) - ChargingSession.session_start,))
     stmt_charge = (
         select(
             func.date_trunc(trunc, ChargingSession.session_start).label("period"),

--- a/backend/app/migrations/versions/32abc4d5e6f8_update_v_daily_consumption.py
+++ b/backend/app/migrations/versions/32abc4d5e6f8_update_v_daily_consumption.py
@@ -36,10 +36,21 @@ def upgrade() -> None:
             p.user_vehicle_id,
             p.park_start_time,
             p.next_park_start_time,
-            (SELECT cs.battery_pct FROM charging_states cs WHERE cs.user_vehicle_id = p.user_vehicle_id AND cs.first_date <= p.park_start_time ORDER BY cs.first_date DESC LIMIT 1) AS start_soc,
-            (SELECT cs.battery_pct FROM charging_states cs WHERE cs.user_vehicle_id = p.user_vehicle_id AND cs.first_date <= COALESCE(p.next_park_start_time, NOW()) ORDER BY cs.first_date DESC LIMIT 1) AS end_soc
-        FROM
-            parked_periods p
+            s_soc.battery_pct AS start_soc,
+            e_soc.battery_pct AS end_soc
+        FROM parked_periods p
+        LEFT JOIN LATERAL (
+            SELECT battery_pct 
+            FROM charging_states cs 
+            WHERE cs.user_vehicle_id = p.user_vehicle_id AND cs.first_date <= p.park_start_time 
+            ORDER BY cs.first_date DESC LIMIT 1
+        ) s_soc ON TRUE
+        LEFT JOIN LATERAL (
+            SELECT battery_pct 
+            FROM charging_states cs 
+            WHERE cs.user_vehicle_id = p.user_vehicle_id AND cs.first_date <= COALESCE(p.next_park_start_time, NOW()) 
+            ORDER BY cs.first_date DESC LIMIT 1
+        ) e_soc ON TRUE
     ),
     consumption_per_cycle AS (
         SELECT

--- a/backend/app/migrations/versions/32abc4d5e6f8_update_v_daily_consumption.py
+++ b/backend/app/migrations/versions/32abc4d5e6f8_update_v_daily_consumption.py
@@ -1,0 +1,121 @@
+"""update v_daily_consumption for live stats
+
+Revision ID: 32abc4d5e6f8
+Revises: 31abc4d5e6f7
+Create Date: 2026-04-17 21:16:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '32abc4d5e6f8'
+down_revision: Union[str, None] = '31abc4d5e6f7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+    CREATE OR REPLACE VIEW v_daily_consumption AS
+    WITH parked_periods AS (
+        SELECT
+            user_vehicle_id,
+            first_date AS park_start_time,
+            LEAD(first_date, 1) OVER (PARTITION BY user_vehicle_id ORDER BY first_date) AS next_park_start_time
+        FROM
+            vehicle_states
+        WHERE
+            state = 'PARKED'
+    ),
+    consumption_cycles AS (
+        SELECT
+            p.user_vehicle_id,
+            p.park_start_time,
+            p.next_park_start_time,
+            (SELECT cs.battery_pct FROM charging_states cs WHERE cs.user_vehicle_id = p.user_vehicle_id AND cs.first_date <= p.park_start_time ORDER BY cs.first_date DESC LIMIT 1) AS start_soc,
+            (SELECT cs.battery_pct FROM charging_states cs WHERE cs.user_vehicle_id = p.user_vehicle_id AND cs.first_date <= COALESCE(p.next_park_start_time, NOW()) ORDER BY cs.first_date DESC LIMIT 1) AS end_soc
+        FROM
+            parked_periods p
+    ),
+    consumption_per_cycle AS (
+        SELECT
+            c.user_vehicle_id,
+            c.park_start_time,
+            uv.battery_capacity_kwh,
+            (c.start_soc - c.end_soc) AS soc_delta
+        FROM
+            consumption_cycles c
+        JOIN
+            user_vehicles uv ON c.user_vehicle_id = uv.id
+        WHERE
+            c.start_soc IS NOT NULL
+            AND c.end_soc IS NOT NULL
+            AND (c.start_soc - c.end_soc) > 0
+            AND uv.battery_capacity_kwh IS NOT NULL
+    )
+    SELECT
+        user_vehicle_id,
+        DATE_TRUNC('day', park_start_time AT TIME ZONE 'UTC')::timestamptz AS consumption_day,
+        SUM((soc_delta / 100.0) * battery_capacity_kwh) AS total_kwh_consumed
+    FROM
+        consumption_per_cycle
+    GROUP BY
+        user_vehicle_id,
+        consumption_day;
+    """)
+
+def downgrade() -> None:
+    op.execute("""
+    CREATE OR REPLACE VIEW v_daily_consumption AS
+    WITH parked_periods AS (
+        SELECT
+            user_vehicle_id,
+            first_date AS park_start_time,
+            LEAD(first_date, 1) OVER (PARTITION BY user_vehicle_id ORDER BY first_date) AS next_park_start_time
+        FROM
+            vehicle_states
+        WHERE
+            state = 'PARKED'
+    ),
+    consumption_cycles AS (
+        SELECT
+            p.user_vehicle_id,
+            p.park_start_time,
+            p.next_park_start_time,
+            (SELECT cs.battery_pct FROM charging_states cs WHERE cs.user_vehicle_id = p.user_vehicle_id AND cs.first_date <= p.park_start_time ORDER BY cs.first_date DESC LIMIT 1) AS start_soc,
+            (SELECT cs.battery_pct FROM charging_states cs WHERE cs.user_vehicle_id = p.user_vehicle_id AND cs.first_date <= p.next_park_start_time ORDER BY cs.first_date DESC LIMIT 1) AS end_soc
+        FROM
+            parked_periods p
+        WHERE
+            p.next_park_start_time IS NOT NULL
+    ),
+    consumption_per_cycle AS (
+        SELECT
+            c.user_vehicle_id,
+            c.park_start_time,
+            uv.battery_capacity_kwh,
+            (c.start_soc - c.end_soc) AS soc_delta
+        FROM
+            consumption_cycles c
+        JOIN
+            user_vehicles uv ON c.user_vehicle_id = uv.id
+        WHERE
+            c.start_soc IS NOT NULL
+            AND c.end_soc IS NOT NULL
+            AND (c.start_soc - c.end_soc) > 0
+            AND uv.battery_capacity_kwh IS NOT NULL
+    )
+    SELECT
+        user_vehicle_id,
+        DATE_TRUNC('day', park_start_time AT TIME ZONE 'UTC')::timestamptz AS consumption_day,
+        SUM((soc_delta / 100.0) * battery_capacity_kwh) AS total_kwh_consumed
+    FROM
+        consumption_per_cycle
+    GROUP BY
+        user_vehicle_id,
+        consumption_day;
+    """)

--- a/backend/app/services/analytics.py
+++ b/backend/app/services/analytics.py
@@ -85,6 +85,24 @@ async def process_completed_trips_and_charges(user_vehicle_id: UUID) -> None:
                             open_trip.avg_temp_celsius = latest_pos.outside_temp_celsius
                         else:
                             open_trip.avg_temp_celsius = (open_trip.avg_temp_celsius + latest_pos.outside_temp_celsius) / 2.0
+                    
+                    # Update live tracking variables
+                    open_trip.end_lat = latest_pos.latitude if latest_pos else open_trip.end_lat
+                    open_trip.end_lon = latest_pos.longitude if latest_pos else open_trip.end_lon
+                    open_trip.end_odometer = latest_odom.mileage_in_km if latest_odom else open_trip.end_odometer
+                    open_trip.end_soc = latest_charge.battery_pct if latest_charge else open_trip.end_soc
+
+                    if open_trip.start_odometer and open_trip.end_odometer:
+                        open_trip.distance_km = float(open_trip.end_odometer - open_trip.start_odometer)
+                        
+                    if open_trip.start_soc and open_trip.end_soc:
+                        soc_used = open_trip.start_soc - open_trip.end_soc
+                        v_res = await session.execute(select(UserVehicle).where(UserVehicle.id == user_vehicle_id))
+                        veh = v_res.scalar_one_or_none()
+                        capacity_kwh = getattr(veh, "battery_capacity_kwh", 77.0) if veh else 77.0
+                        if capacity_kwh is None: capacity_kwh = 77.0
+                        if soc_used > 0:
+                            open_trip.kwh_consumed = (soc_used / 100.0) * capacity_kwh
             else:
                 if open_trip:
                     # End the trip! Calculate deltas.
@@ -152,6 +170,20 @@ async def process_completed_trips_and_charges(user_vehicle_id: UUID) -> None:
                             open_charge.avg_temp_celsius = latest_pos.outside_temp_celsius
                         else:
                             open_charge.avg_temp_celsius = (open_charge.avg_temp_celsius + latest_pos.outside_temp_celsius) / 2.0
+                    
+                    # Update live charging variables
+                    open_charge.end_level = latest_charge.battery_pct if latest_charge else open_charge.end_level
+                    
+                    if open_charge.start_level and open_charge.end_level:
+                        soc_added = open_charge.end_level - open_charge.start_level
+                        v_res = await session.execute(select(UserVehicle).where(UserVehicle.id == user_vehicle_id))
+                        veh = v_res.scalar_one_or_none()
+                        capacity_kwh = getattr(veh, "battery_capacity_kwh", 77.0) if veh else 77.0
+                        if capacity_kwh is None: capacity_kwh = 77.0
+                        
+                        if soc_added > 0:
+                            added_kwh = (soc_added / 100.0) * capacity_kwh
+                            open_charge.energy_kwh = added_kwh
             else:
                 if open_charge:
                     open_charge.session_end = datetime.now(UTC)

--- a/frontend/src/components/statistics/CarOverviewDashboard.tsx
+++ b/frontend/src/components/statistics/CarOverviewDashboard.tsx
@@ -270,11 +270,12 @@ export function CarOverviewDashboard({
 
   useEffect(() => {
     fetchData();
-    const interval = setInterval(() => {
-      fetchData();
-    }, 60000);
+    const isLive = !toISOVal || new Date(toISOVal) >= new Date();
+    if (!isLive) return;
+
+    const interval = setInterval(fetchData, 60000);
     return () => clearInterval(interval);
-  }, [fetchData]);
+  }, [fetchData, toISOVal]);
 
   const toggle = (id: StateToggleId) => {
     setGlobalToggles((prev) => {

--- a/frontend/src/components/statistics/CarOverviewDashboard.tsx
+++ b/frontend/src/components/statistics/CarOverviewDashboard.tsx
@@ -270,6 +270,10 @@ export function CarOverviewDashboard({
 
   useEffect(() => {
     fetchData();
+    const interval = setInterval(() => {
+      fetchData();
+    }, 60000);
+    return () => clearInterval(interval);
   }, [fetchData]);
 
   const toggle = (id: StateToggleId) => {

--- a/frontend/src/components/statistics/ChargingStatisticsDashboard.tsx
+++ b/frontend/src/components/statistics/ChargingStatisticsDashboard.tsx
@@ -47,11 +47,12 @@ export function ChargingStatisticsDashboard({
 
   useEffect(() => {
     fetchData();
-    const interval = setInterval(() => {
-      fetchData();
-    }, 60000);
+    const isLive = !toISO || new Date(toISO) >= new Date();
+    if (!isLive) return;
+
+    const interval = setInterval(fetchData, 60000);
     return () => clearInterval(interval);
-  }, [fetchData]);
+  }, [fetchData, toISO]);
 
   const totalCharges = stats.reduce((acc, r) => acc + r.charging_sessions_count, 0);
   const totalEnergy = stats.reduce((acc, r) => acc + r.total_energy_kwh, 0);

--- a/frontend/src/components/statistics/ChargingStatisticsDashboard.tsx
+++ b/frontend/src/components/statistics/ChargingStatisticsDashboard.tsx
@@ -47,6 +47,10 @@ export function ChargingStatisticsDashboard({
 
   useEffect(() => {
     fetchData();
+    const interval = setInterval(() => {
+      fetchData();
+    }, 60000);
+    return () => clearInterval(interval);
   }, [fetchData]);
 
   const totalCharges = stats.reduce((acc, r) => acc + r.charging_sessions_count, 0);

--- a/frontend/src/components/statistics/DrivingStatisticsDashboard.tsx
+++ b/frontend/src/components/statistics/DrivingStatisticsDashboard.tsx
@@ -76,12 +76,12 @@ export function DrivingStatisticsDashboard({
 
   useEffect(() => {
     fetchData();
-    // Live incremental refresh for the current day
-    const interval = setInterval(() => {
-      fetchData();
-    }, 60000); // Poll every 1 minute
+    const isLive = !toISO || new Date(toISO) >= new Date();
+    if (!isLive) return;
+
+    const interval = setInterval(fetchData, 60000);
     return () => clearInterval(interval);
-  }, [fetchData]);
+  }, [fetchData, toISO]);
 
   const latestData = rows.length > 0 ? rows[0] : null;
   const historicalData = rows.length > 1 ? rows.slice(1) : [];

--- a/frontend/src/components/statistics/DrivingStatisticsDashboard.tsx
+++ b/frontend/src/components/statistics/DrivingStatisticsDashboard.tsx
@@ -76,6 +76,11 @@ export function DrivingStatisticsDashboard({
 
   useEffect(() => {
     fetchData();
+    // Live incremental refresh for the current day
+    const interval = setInterval(() => {
+      fetchData();
+    }, 60000); // Poll every 1 minute
+    return () => clearInterval(interval);
   }, [fetchData]);
 
   const latestData = rows.length > 0 ? rows[0] : null;

--- a/frontend/src/components/statistics/LocationsDashboard.tsx
+++ b/frontend/src/components/statistics/LocationsDashboard.tsx
@@ -43,11 +43,12 @@ export function LocationsDashboard({ vehicleId, dateRange }: LocationsDashboardP
 
   useEffect(() => {
     fetchData();
-    const interval = setInterval(() => {
-      fetchData();
-    }, 60000);
+    const isLive = !toISO || new Date(toISO) >= new Date();
+    if (!isLive) return;
+
+    const interval = setInterval(fetchData, 60000);
     return () => clearInterval(interval);
-  }, [fetchData]);
+  }, [fetchData, toISO]);
 
   const distinctPlaces = new Set(positions.map((p) => placeKey(p.latitude, p.longitude))).size;
   const lastPositions = [...positions]

--- a/frontend/src/components/statistics/LocationsDashboard.tsx
+++ b/frontend/src/components/statistics/LocationsDashboard.tsx
@@ -43,6 +43,10 @@ export function LocationsDashboard({ vehicleId, dateRange }: LocationsDashboardP
 
   useEffect(() => {
     fetchData();
+    const interval = setInterval(() => {
+      fetchData();
+    }, 60000);
+    return () => clearInterval(interval);
   }, [fetchData]);
 
   const distinctPlaces = new Set(positions.map((p) => placeKey(p.latitude, p.longitude))).size;

--- a/frontend/src/components/statistics/MileageKMDashboard.tsx
+++ b/frontend/src/components/statistics/MileageKMDashboard.tsx
@@ -96,11 +96,12 @@ export function MileageKMDashboard({ vehicleId, dateRange }: MileageKMDashboardP
 
   useEffect(() => {
     fetchData();
-    const interval = setInterval(() => {
-      fetchData();
-    }, 60000);
+    const isLive = !toISOVal || new Date(toISOVal) >= new Date();
+    if (!isLive) return;
+
+    const interval = setInterval(fetchData, 60000);
     return () => clearInterval(interval);
-  }, [fetchData]);
+  }, [fetchData, toISOVal]);
 
   if (loading) {
     return (

--- a/frontend/src/components/statistics/MileageKMDashboard.tsx
+++ b/frontend/src/components/statistics/MileageKMDashboard.tsx
@@ -96,6 +96,10 @@ export function MileageKMDashboard({ vehicleId, dateRange }: MileageKMDashboardP
 
   useEffect(() => {
     fetchData();
+    const interval = setInterval(() => {
+      fetchData();
+    }, 60000);
+    return () => clearInterval(interval);
   }, [fetchData]);
 
   if (loading) {

--- a/frontend/src/components/statistics/VisitedDashboard.tsx
+++ b/frontend/src/components/statistics/VisitedDashboard.tsx
@@ -43,11 +43,12 @@ export function VisitedDashboard({ vehicleId, dateRange }: VisitedDashboardProps
 
   useEffect(() => {
     fetchData();
-    const interval = setInterval(() => {
-      fetchData();
-    }, 60000);
+    const isLive = !toISOVal || new Date(toISOVal) >= new Date();
+    if (!isLive) return;
+
+    const interval = setInterval(fetchData, 60000);
     return () => clearInterval(interval);
-  }, [fetchData]);
+  }, [fetchData, toISOVal]);
 
   if (loading) {
     return (

--- a/frontend/src/components/statistics/VisitedDashboard.tsx
+++ b/frontend/src/components/statistics/VisitedDashboard.tsx
@@ -43,6 +43,10 @@ export function VisitedDashboard({ vehicleId, dateRange }: VisitedDashboardProps
 
   useEffect(() => {
     fetchData();
+    const interval = setInterval(() => {
+      fetchData();
+    }, 60000);
+    return () => clearInterval(interval);
   }, [fetchData]);
 
   if (loading) {


### PR DESCRIPTION
### **User description**
## 📋 Summary

Implemented live incremental updates for the current day's driving and charging statistics.
Modified `analytics.py` to update active trips and charging sessions incrementally in real-time.
Modified `vehicles.py` API to calculate time_driven and time_charging for active sessions accurately using `func.now()`.
Updated the `v_daily_consumption` SQL view via an Alembic migration to include ongoing consumption cycles by coalescing `next_park_start_time` with `NOW()`.
Added a 60-second polling interval to all frontend dashboard components (`useEffect` with `setInterval`) to pull live data.

**Related Issues:** Closes Task b55da2a3


---

## 🧩 Type of Change

- [ ] 🆕 New feature (e.g. new dashboard, API endpoint)
- [x] 🐛 Bug fix
- [x] ⚙️ Backend change (API, collector, database)
- [x] 🎨 Frontend change (UI, charts, pages)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

- [x] Backend runs and tests pass (if applicable)
- [x] Frontend builds (`npm run build` in `frontend/`)
- [x] Manual testing done (if applicable)

---

## 👥 Reviewer Notes

Focus on the SQL changes in `v_daily_consumption` view and ensure `analytics.py` updates to `open_trip` and `open_charge` don't interfere with the closing logic.


---

## 📌 Additional Context

Addresses the "Driving Stats Fix" prioritized by m7xlabpm.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Implements 60-second auto-refresh for all dashboard components.

- Updates backend to calculate live durations using `now()`.

- Enhances `analytics.py` to track ongoing trip/charge metrics.

- Modifies SQL view to include current consumption cycles.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Frontend
    UI["Dashboard Components"] -- "Polls every 60s" --> API
  end
  subgraph Backend
    API["Vehicles API"] -- "Uses func.now()" --> DB[(PostgreSQL)]
    Analytics["Analytics Service"] -- "Updates open sessions" --> DB
  end
  subgraph Database
    DB -- "v_daily_consumption" --> View["Updated SQL View"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>CarOverviewDashboard.tsx</strong><dd><code>Add 60-second polling interval for live data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/69/files#diff-f9450d61618a941d48fef288fa67384a46d183bc698cf27ef74cd028adf49eed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ChargingStatisticsDashboard.tsx</strong><dd><code>Implement periodic data fetching every minute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/69/files#diff-096644c4bfb321dadcc29dc66e4165f2d60699ddbc6f6f2c48290b2429ee9fd9">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DrivingStatisticsDashboard.tsx</strong><dd><code>Enable live incremental refresh for driving stats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/69/files#diff-9739e1957b6eb71d909205d7e8c1a6bba80e62273566bbe49e4007b8dcc183d8">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LocationsDashboard.tsx</strong><dd><code>Add auto-refresh logic to locations dashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/69/files#diff-91936266f7843ce86a82c620418640a150bdc7e1f31c9771775c98ffde3c284e">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MileageKMDashboard.tsx</strong><dd><code>Set up 60s interval for mileage updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/69/files#diff-698002d8ab8f7d7f9820fb249a3997603c54c94bf6e70316bc8c253a71e5bd19">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>VisitedDashboard.tsx</strong><dd><code>Add periodic refresh for visited locations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/69/files#diff-3e1dbe08e776ce0b67654742af7ebb750188183f97f9ff43d94622680c1b89e5">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>analytics.py</strong><dd><code>Update open trip and charge metrics incrementally</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/69/files#diff-e66b912161b03c0da6b5e2241f0ab3a5701d1e2ba5c00f567974c4bd1fe7e191">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>vehicles.py</strong><dd><code>Calculate live duration for active sessions using now()</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/69/files#diff-e0ad806f7f5d6a9fafbabd69de3ca022741428c9494b44af10a084474d3a2f8d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>32abc4d5e6f8_update_v_daily_consumption.py</strong><dd><code>Update consumption view to include ongoing cycles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/69/files#diff-cb9be9839e1d0c21061b17ebdcb084726b4d6ddaa3df0d4be11ff8426075d144">+121/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

