### PR TITLE
feat(security): implement double-submit CSRF protection

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -195,6 +195,7 @@ async def login(response: Response, body: LoginRequest, db: AsyncSession = Depen
 
     access_token = create_access_token(str(user.id))
     refresh_token = create_refresh_token(str(user.id))
+    csrf_token = str(uuid.uuid4())
     
     response.set_cookie(
         key="access_token",
@@ -211,6 +212,13 @@ async def login(response: Response, body: LoginRequest, db: AsyncSession = Depen
         secure=not settings.debug if hasattr(settings, "debug") else False,
         samesite="lax",
         max_age=settings.refresh_token_expire_days * 24 * 60 * 60,
+    )
+    response.set_cookie(
+        key="csrf_token",
+        value=csrf_token,
+        httponly=False,
+        secure=not settings.debug if hasattr(settings, "debug") else False,
+        samesite="lax",
     )
 
     return LoginResponse(
@@ -268,8 +276,10 @@ async def verify_2fa_login(response: Response, body: TwoFactorLoginRequest, db: 
 
     access_token = create_access_token(str(user.id))
     refresh_token = create_refresh_token(str(user.id))
+    csrf_token = str(uuid.uuid4())
     response.set_cookie(key="access_token", value=access_token, httponly=True, secure=not settings.debug if hasattr(settings, "debug") else False, samesite="lax", max_age=settings.access_token_expire_minutes * 60)
     response.set_cookie(key="refresh_token", value=refresh_token, httponly=True, secure=not settings.debug if hasattr(settings, "debug") else False, samesite="lax", max_age=settings.refresh_token_expire_days * 24 * 60 * 60)
+    response.set_cookie(key="csrf_token", value=csrf_token, httponly=False, secure=not settings.debug if hasattr(settings, "debug") else False, samesite="lax")
     return TokenResponse(
         access_token=access_token,
         refresh_token=refresh_token,
@@ -329,8 +339,10 @@ async def verify_recovery_code_login(response: Response, body: RecoveryCodeLogin
 
     access_token = create_access_token(str(user.id))
     refresh_token = create_refresh_token(str(user.id))
+    csrf_token = str(uuid.uuid4())
     response.set_cookie(key="access_token", value=access_token, httponly=True, secure=not settings.debug if hasattr(settings, "debug") else False, samesite="lax", max_age=settings.access_token_expire_minutes * 60)
     response.set_cookie(key="refresh_token", value=refresh_token, httponly=True, secure=not settings.debug if hasattr(settings, "debug") else False, samesite="lax", max_age=settings.refresh_token_expire_days * 24 * 60 * 60)
+    response.set_cookie(key="csrf_token", value=csrf_token, httponly=False, secure=not settings.debug if hasattr(settings, "debug") else False, samesite="lax")
     return TokenResponse(
         access_token=access_token,
         refresh_token=refresh_token,
@@ -371,8 +383,10 @@ async def refresh(request: Request, response: Response, body: RefreshRequest = N
 
     access_token = create_access_token(subject)
     new_refresh = create_refresh_token(subject)
+    csrf_token = str(uuid.uuid4())
     response.set_cookie(key="access_token", value=access_token, httponly=True, secure=not settings.debug if hasattr(settings, "debug") else False, samesite="lax", max_age=settings.access_token_expire_minutes * 60)
     response.set_cookie(key="refresh_token", value=new_refresh, httponly=True, secure=not settings.debug if hasattr(settings, "debug") else False, samesite="lax", max_age=settings.refresh_token_expire_days * 24 * 60 * 60)
+    response.set_cookie(key="csrf_token", value=csrf_token, httponly=False, secure=not settings.debug if hasattr(settings, "debug") else False, samesite="lax")
     return TokenResponse(
         access_token=access_token,
         refresh_token=new_refresh,
@@ -392,6 +406,12 @@ async def logout(response: Response, request: Request, body: RefreshRequest = No
     response.delete_cookie(
         key="refresh_token", 
         httponly=True, 
+        secure=not settings.debug if hasattr(settings, "debug") else False,
+        samesite="lax"
+    )
+    response.delete_cookie(
+        key="csrf_token", 
+        httponly=False, 
         secure=not settings.debug if hasattr(settings, "debug") else False,
         samesite="lax"
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -116,7 +116,9 @@ async def csrf_middleware(request: Request, call_next):
             "/api/v1/auth/reset-password",
             "/api/v1/auth/invite-request"
         ]
-        if request.url.path not in exempt_paths:
+        # Strip trailing slash for consistent exemption matching
+        normalized_path = request.url.path.rstrip("/")
+        if normalized_path not in exempt_paths:
             csrf_cookie = request.cookies.get("csrf_token")
             csrf_header = request.headers.get("x-csrf-token")
             if not csrf_cookie or not csrf_header or not secrets.compare_digest(csrf_cookie, csrf_header):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -102,6 +102,29 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+@app.middleware("http")
+async def csrf_middleware(request: Request, call_next):
+    if request.method in ["POST", "PUT", "DELETE", "PATCH"]:
+        exempt_paths = [
+            "/api/v1/auth/login",
+            "/api/v1/auth/refresh",
+            "/api/v1/auth/login/verify-2fa",
+            "/api/v1/auth/login/verify-recovery-code",
+            "/api/v1/auth/register",
+            "/api/v1/auth/forgot-password",
+            "/api/v1/auth/reset-password",
+            "/api/v1/auth/invite-request"
+        ]
+        if request.url.path not in exempt_paths:
+            csrf_cookie = request.cookies.get("csrf_token")
+            csrf_header = request.headers.get("x-csrf-token")
+            if not csrf_cookie or not csrf_header or csrf_cookie != csrf_header:
+                return JSONResponse(
+                    status_code=403,
+                    content={"detail": "CSRF token missing or incorrect"}
+                )
+    return await call_next(request)
+
 app.add_middleware(CacheMiddleware)
 
 app.add_middleware(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ from contextlib import asynccontextmanager
 import logging
 import sys
 
+import secrets
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
@@ -118,7 +119,7 @@ async def csrf_middleware(request: Request, call_next):
         if request.url.path not in exempt_paths:
             csrf_cookie = request.cookies.get("csrf_token")
             csrf_header = request.headers.get("x-csrf-token")
-            if not csrf_cookie or not csrf_header or csrf_cookie != csrf_header:
+            if not csrf_cookie or not csrf_header or not secrets.compare_digest(csrf_cookie, csrf_header):
                 return JSONResponse(
                     status_code=403,
                     content={"detail": "CSRF token missing or incorrect"}

--- a/frontend/src/lib/api/core.ts
+++ b/frontend/src/lib/api/core.ts
@@ -105,7 +105,7 @@ export function invalidateApiCache(vehicleId?: string) {
 export function getCookie(name: string): string | null {
   if (typeof document === "undefined") return null;
   const match = document.cookie.match(new RegExp("(^| )" + name + "=([^;]+)"));
-  if (match) return match[2];
+  if (match) return decodeURIComponent(match[2]);
   return null;
 }
 

--- a/frontend/src/lib/api/core.ts
+++ b/frontend/src/lib/api/core.ts
@@ -102,6 +102,13 @@ export function invalidateApiCache(vehicleId?: string) {
   }
 }
 
+export function getCookie(name: string): string | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(new RegExp("(^| )" + name + "=([^;]+)"));
+  if (match) return match[2];
+  return null;
+}
+
 export async function apiFetch(
   path: string,
   options: RequestInit = {}
@@ -110,6 +117,14 @@ export async function apiFetch(
     "Content-Type": "application/json",
     ...(options.headers as Record<string, string>),
   };
+
+  const method = options.method?.toUpperCase() || "GET";
+  if (["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
+    const csrfToken = getCookie("csrf_token");
+    if (csrfToken) {
+      headers["X-CSRF-Token"] = csrfToken;
+    }
+  }
 
   const fetchOptions: RequestInit = {
     ...options,


### PR DESCRIPTION
### **User description**
## 📋 Summary

Adds CSRF middleware validation to backend mutations and automatically attaches X-CSRF-Token headers from cookies on frontend.
<!-- 🤖 PR Agent will automatically enhance this description with detailed file walkthrough -->
<!-- ⚠️ This section must be filled out (at least 20 characters) for PR validation to pass -->

**Related Issues:** Closes #


---

## 🧩 Type of Change

<!-- Mark the relevant option with an 'x' - At least one must be checked for PR validation -->

- [ ] 🆕 New feature (e.g. new dashboard, API endpoint)
- [ ] 🐛 Bug fix
- [x] ⚙️ Backend change (API, collector, database)
- [ ] 🎨 Frontend change (UI, charts, pages)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

<!-- Mark completed items with an 'x' -->

- [ ] Backend runs and tests pass (if applicable)
- [ ] Frontend builds (`npm run build` in `frontend/`)
- [ ] Manual testing done (if applicable)

---

## 👥 Reviewer Notes

<!-- What should reviewers focus on? Any specific questions or areas of uncertainty? -->


---

## 📌 Additional Context

<!-- Any other context, links to documentation, or important notes -->


___

### **PR Type**
Enhancement


___

### **Description**
- Implements double-submit cookie CSRF protection across the application.

- Generates and sets a `csrf_token` cookie during login and token refresh.

- Adds backend middleware to validate the `X-CSRF-Token` header against the cookie for mutations.

- Updates the frontend API client to automatically attach the CSRF token to state-changing requests.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Frontend
    A["apiFetch"] -- "Extracts cookie" --> B["X-CSRF-Token Header"]
  end
  subgraph Backend
    C["Auth Endpoints"] -- "Sets" --> D["csrf_token Cookie"]
    E["CSRF Middleware"] -- "Validates" --> F["Cookie == Header"]
  end
  B -- "Request" --> E
  D -- "Response" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>core.ts</strong><dd><code>Automate CSRF header attachment in frontend API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/lib/api/core.ts

<ul><li>Added a <code>getCookie</code> utility function to retrieve cookie values by name.<br> <li> Modified <code>apiFetch</code> to automatically include the <code>X-CSRF-Token</code> header for <br>POST, PUT, PATCH, and DELETE requests if the cookie exists.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/74/files#diff-ee2f623abc3876c4d6b55834339ae10076ca21a7826fbed6f4d6dec0ed1a0855">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>auth.py</strong><dd><code>Manage CSRF tokens in authentication lifecycle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/api/v1/auth.py

<ul><li>Generates a unique UUID for <code>csrf_token</code> during login, 2FA verification, <br>and token refresh.<br> <li> Sets the <code>csrf_token</code> cookie with <code>httponly=False</code> to allow frontend <br>access.<br> <li> Ensures the <code>csrf_token</code> cookie is deleted upon logout.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/74/files#diff-9d56dc7e7a4fc32e337ea47210398bb73d71e348e76139578ede19f6daf2d44e">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Implement backend CSRF validation middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/main.py

<ul><li>Introduced a global HTTP middleware to enforce CSRF validation.<br> <li> Compares the <code>csrf_token</code> cookie with the <code>x-csrf-token</code> header for <br>mutation methods.<br> <li> Defines a list of exempt paths, primarily for initial authentication <br>and password recovery.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/74/files#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

