### PR TITLE
fix(frontend): restore DateRangePicker for Trips tab in Advanced Statistics

### DIFF
--- a/frontend/src/app/(dashboard)/vehicles/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/vehicles/[id]/page.tsx
@@ -927,7 +927,7 @@ export default function VehicleDetailPage() {
       {tab === "trips" && (() => {
         const to = new Date();
         const from = new Date(to.getTime() - 30 * 24 * 60 * 60 * 1000);
-        return <TripsDashboard vehicleId={vehicleId} dateRange={{ from, to }} />;
+        return <TripsDashboard vehicleId={vehicleId} dateRange={{ from, to }} summarySubtitle="Last 30 Days" />;
       })()}
 
       {/* ===== STATISTICS (Helicopter View) ===== */}

--- a/frontend/src/components/statistics/StatisticsShell.tsx
+++ b/frontend/src/components/statistics/StatisticsShell.tsx
@@ -85,14 +85,12 @@ export function StatisticsShell({ vehicleId }: { vehicleId: string }) {
             ))}
           </Tabs.List>
 
-          {activeTab !== "trips" && (
-            <div className="flex items-center gap-3 justify-center md:justify-start self-start md:self-auto">
-              <span className="text-xs font-medium text-iv-text-muted uppercase tracking-wider whitespace-nowrap hidden sm:inline-block">
-                Period
-              </span>
-              <DateRangePicker value={dateRange} onChange={setDateRange} />
-            </div>
-          )}
+          <div className="flex items-center gap-3 justify-center md:justify-start self-start md:self-auto">
+            <span className="text-xs font-medium text-iv-text-muted uppercase tracking-wider whitespace-nowrap hidden sm:inline-block">
+              Period
+            </span>
+            <DateRangePicker value={dateRange} onChange={setDateRange} />
+          </div>
         </div>
 
         <div className="animate-in fade-in duration-500">
@@ -110,7 +108,7 @@ export function StatisticsShell({ vehicleId }: { vehicleId: string }) {
           </Tabs.Content>
           
           <Tabs.Content value="trips">
-            <TripsDashboard vehicleId={vehicleId} />
+            <TripsDashboard vehicleId={vehicleId} dateRange={range} />
           </Tabs.Content>
           <Tabs.Content value="movement">
             <MovementDashboard vehicleId={vehicleId} dateRange={range} />

--- a/frontend/src/components/statistics/TripsDashboard.tsx
+++ b/frontend/src/components/statistics/TripsDashboard.tsx
@@ -12,6 +12,7 @@ import "leaflet/dist/leaflet.css";
 export interface TripsDashboardProps {
   vehicleId: string;
   dateRange?: { from: Date; to: Date }; // Statistics page usage
+  summarySubtitle?: string;
 }
 
 interface TripAnalyticsItem {
@@ -93,7 +94,7 @@ function getPolylinePositions(trip: TripAnalyticsItem): [[number, number], [numb
 }
 
 // --- Main Component ---
-export function TripsDashboard({ vehicleId, dateRange }: TripsDashboardProps) {
+export function TripsDashboard({ vehicleId, dateRange, summarySubtitle }: TripsDashboardProps) {
   const [allTrips, setAllTrips] = useState<TripAnalyticsItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [activeTripId, setActiveTripId] = useState<number | null>(null);
@@ -249,7 +250,10 @@ export function TripsDashboard({ vehicleId, dateRange }: TripsDashboardProps) {
       {dateRange && (
         <div className="glass rounded-2xl p-6 space-y-4">
           <div className="flex items-center justify-between">
-            <h3 className="text-sm font-semibold text-iv-text">Trip Summary</h3>
+            <div className="flex items-baseline gap-2">
+              <h3 className="text-sm font-semibold text-iv-text">Trip Summary</h3>
+              {summarySubtitle && <span className="text-xs font-medium text-iv-muted">({summarySubtitle})</span>}
+            </div>
           </div>
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
             <div className="bg-iv-surface/60 rounded-xl p-4 border border-iv-border/50">


### PR DESCRIPTION
### **User description**
## 📋 Summary

Restores the global DateRangePicker calendar for the Trips tab to maintain consistency with all other subpages in Advanced Statistics.
<!-- 🤖 PR Agent will automatically enhance this description with detailed file walkthrough -->
<!-- ⚠️ This section must be filled out (at least 20 characters) for PR validation to pass -->

**Related Issues:** Closes #


---

## 🧩 Type of Change

<!-- Mark the relevant option with an 'x' - At least one must be checked for PR validation -->

- [ ] 🆕 New feature (e.g. new dashboard, API endpoint)
- [ ] 🐛 Bug fix
- [ ] ⚙️ Backend change (API, collector, database)
- [x] 🎨 Frontend change (UI, charts, pages)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

<!-- Mark completed items with an 'x' -->

- [ ] Backend runs and tests pass (if applicable)
- [ ] Frontend builds (`npm run build` in `frontend/`)
- [ ] Manual testing done (if applicable)

---

## 👥 Reviewer Notes

<!-- What should reviewers focus on? Any specific questions or areas of uncertainty? -->


---

## 📌 Additional Context

<!-- Any other context, links to documentation, or important notes -->


___

### **PR Type**
Enhancement


___

### **Description**
- Restores DateRangePicker visibility for the Trips tab.

- Passes dateRange prop to the TripsDashboard component.

- Ensures UI consistency across all Advanced Statistics tabs.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SS["StatisticsShell.tsx"] -- "Removes conditional check" --> DRP["DateRangePicker"]
  SS -- "Passes dateRange prop" --> TD["TripsDashboard"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StatisticsShell.tsx</strong><dd><code>Enable DateRangePicker and pass range to Trips tab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/statistics/StatisticsShell.tsx

<ul><li>Removed the conditional logic that hid the <code>DateRangePicker</code> when the <br>'trips' tab was active.<br> <li> Updated the <code>TripsDashboard</code> component call to include the <code>dateRange</code> <br>prop, enabling time-based filtering for trips.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/75/files#diff-d54d4ce1df8218f2c18ff67b47985580386cb2e50b9f414b8a1e5dd7b5bcff42">+7/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

