### PR TITLE
feat(analytics): charging curve integrals and wasted time calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the iVDrive project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2026-04-22
+
+### Added 🌟
+- **Charging Curve Integrals**: Implemented a new backend endpoint to map SoC vs. Power (kW) and accurately calculate time wasted charging from 80% to 100%. Added a visual Recharts dashboard to the Statistics view.
+
+## [v1.0.21.1] - 2026-04-20
+
+### Fixed 🐛
+- **Data Extraction AES Encryption Crash**: Safely reverted an aggressive in-memory password clearing mechanism inside the threaded worker that caused a Python scope collision (`UnboundLocalError`) during the AES-256 zip encryption process, resulting in silent failures for user data exports.
+
 ## [v1.0.21] - 2026-04-20
 
 ### Added 🌟

--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -614,34 +614,31 @@ async def get_charging_curve_integrals(
     ]
 
     # 2. Time wasted calculation: duration of charging >= 80%
-    stmt_time = (
+    from sqlalchemy import case
+    stmt_metrics = (
         select(
-            ChargingState.battery_pct,
-            ChargingState.first_date,
-            ChargingState.last_date
+            case(
+                (ChargingState.battery_pct >= 80, "wasted"),
+                else_="fast"
+            ).label("category"),
+            func.sum(
+                func.least(
+                    func.greatest(0, func.extract("epoch", ChargingState.last_date - ChargingState.first_date)),
+                    1800
+                )
+            ).label("total_seconds")
         )
         .where(
             ChargingState.user_vehicle_id == vehicle_id,
             ChargingState.state == "CHARGING"
         )
+        .group_by("category")
     )
-    result_time = await db.execute(stmt_time)
-    time_rows = result_time.all()
-
-    fast_charge_seconds = 0.0
-    wasted_seconds = 0.0
+    res = await db.execute(stmt_metrics)
+    metrics_map = {row.category: row.total_seconds for row in res.all()}
     
-    for row in time_rows:
-        duration = (row.last_date - row.first_date).total_seconds()
-        duration = max(0.0, duration)
-        # Avoid absurd durations from gaps, cap at say 30 mins (1800s) per state
-        duration = min(duration, 1800.0) 
-        
-        soc = row.battery_pct or 0
-        if soc >= 80:
-            wasted_seconds += duration
-        else:
-            fast_charge_seconds += duration
+    wasted_seconds = metrics_map.get("wasted", 0.0) or 0.0
+    fast_charge_seconds = metrics_map.get("fast", 0.0) or 0.0
 
     wasted_minutes = round(wasted_seconds / 60)
     fast_charge_minutes = round(fast_charge_seconds / 60)

--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -570,6 +570,91 @@ async def get_time_budget(
         "offline_seconds":  round(state_seconds.get("OFFLINE", 0)),
     }
 
+@router.get("/{vehicle_id}/analytics/charging-curve-integrals")
+async def get_charging_curve_integrals(
+    vehicle_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    """
+    Plot Charging Power (kW) over SoC (%) and calculate the "wasted time"
+    (time spent charging from 80% to 100%).
+    """
+    await get_user_vehicle(user.id, vehicle_id, db)
+    
+    # 1. Curve data: Average Power kW per SoC %
+    # Using ChargingState for a more consistent representation across all sessions
+    stmt_curve = (
+        select(
+            ChargingState.battery_pct.label("soc"),
+            func.avg(ChargingState.charge_power_kw).label("avg_power"),
+            func.max(ChargingState.charge_power_kw).label("max_power"),
+            func.count(ChargingState.id).label("samples")
+        )
+        .where(
+            ChargingState.user_vehicle_id == vehicle_id,
+            ChargingState.state == "CHARGING",
+            ChargingState.charge_power_kw > 0,
+            ChargingState.battery_pct.is_not(None)
+        )
+        .group_by(ChargingState.battery_pct)
+        .order_by(ChargingState.battery_pct)
+    )
+    result_curve = await db.execute(stmt_curve)
+    curve_data = result_curve.all()
+    
+    curve = [
+        {
+            "soc_pct": row.soc,
+            "avg_power_kw": round(float(row.avg_power), 2),
+            "max_power_kw": round(float(row.max_power), 2),
+            "samples": row.samples
+        }
+        for row in curve_data
+    ]
+
+    # 2. Time wasted calculation: duration of charging >= 80%
+    stmt_time = (
+        select(
+            ChargingState.battery_pct,
+            ChargingState.first_date,
+            ChargingState.last_date
+        )
+        .where(
+            ChargingState.user_vehicle_id == vehicle_id,
+            ChargingState.state == "CHARGING"
+        )
+    )
+    result_time = await db.execute(stmt_time)
+    time_rows = result_time.all()
+
+    fast_charge_seconds = 0.0
+    wasted_seconds = 0.0
+    
+    for row in time_rows:
+        duration = (row.last_date - row.first_date).total_seconds()
+        duration = max(0.0, duration)
+        # Avoid absurd durations from gaps, cap at say 30 mins (1800s) per state
+        duration = min(duration, 1800.0) 
+        
+        soc = row.battery_pct or 0
+        if soc >= 80:
+            wasted_seconds += duration
+        else:
+            fast_charge_seconds += duration
+
+    wasted_minutes = round(wasted_seconds / 60)
+    fast_charge_minutes = round(fast_charge_seconds / 60)
+
+    return {
+        "curve": curve,
+        "metrics": {
+            "wasted_minutes_80_100": wasted_minutes,
+            "fast_charge_minutes_0_80": fast_charge_minutes,
+            "total_charging_minutes": wasted_minutes + fast_charge_minutes
+        }
+    }
+
 @router.get("/{vehicle_id}/analytics/advanced-overview")
 async def get_advanced_analytics_overview(
     vehicle_id: UUID,

--- a/frontend/src/components/statistics/ChargingCurveDashboard.tsx
+++ b/frontend/src/components/statistics/ChargingCurveDashboard.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from "recharts";
+import { Loader2, Zap, Clock, BatteryWarning } from "lucide-react";
+import { api } from "@/lib/api";
+
+interface CurvePoint {
+  soc_pct: number;
+  avg_power_kw: number;
+  max_power_kw: number;
+  samples: number;
+}
+
+interface Metrics {
+  wasted_minutes_80_100: number;
+  fast_charge_minutes_0_80: number;
+  total_charging_minutes: number;
+}
+
+interface ChargingCurveData {
+  curve: CurvePoint[];
+  metrics: Metrics;
+}
+
+export function ChargingCurveDashboard({ vehicleId }: { vehicleId: string }) {
+  const [data, setData] = useState<ChargingCurveData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      // Assuming api.fetchWrapper can be used or just use native fetch if not defined
+      const token = localStorage.getItem("access_token");
+      const res = await fetch(`/api/v1/vehicles/${vehicleId}/analytics/charging-curve-integrals`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      if (res.ok) {
+        const json = await res.json();
+        setData(json);
+      } else {
+        setData(null);
+      }
+    } catch {
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [vehicleId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-8 w-8 animate-spin text-iv-muted" />
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="flex items-center justify-center py-12 text-iv-muted">
+        Failed to load charging curve data.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-iv-muted">
+        Charging power across different battery levels (SoC), highlighting the time spent charging the last 20%.
+      </p>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div className="flex items-center gap-4 rounded-lg border border-iv-border bg-iv-surface p-4">
+          <div className="rounded-lg bg-iv-cyan/15 p-3">
+            <Zap className="h-6 w-6 text-iv-cyan" />
+          </div>
+          <div>
+            <p className="text-xs font-medium text-iv-muted">Fast Charging (0-80%)</p>
+            <p className="text-2xl font-bold text-iv-text">{data.metrics.fast_charge_minutes_0_80} min</p>
+            <p className="text-xs text-iv-muted">average accumulated time</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-4 rounded-lg border border-iv-border bg-iv-surface p-4">
+          <div className="rounded-lg bg-red-500/15 p-3">
+            <Clock className="h-6 w-6 text-red-500" />
+          </div>
+          <div>
+            <p className="text-xs font-medium text-iv-muted">Time Wasted (80-100%)</p>
+            <p className="text-2xl font-bold text-red-400">{data.metrics.wasted_minutes_80_100} min</p>
+            <p className="text-xs text-iv-muted">total accumulated time wasted</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-iv-border bg-iv-surface">
+        <div className="flex items-center gap-2 border-b border-iv-border px-4 py-3">
+          <BatteryWarning className="h-5 w-5 text-iv-muted" />
+          <h3 className="font-medium text-iv-text">Charging Power Curve</h3>
+        </div>
+        
+        {data.curve.length === 0 ? (
+          <div className="px-4 py-8 text-center text-sm text-iv-muted">No curve data available.</div>
+        ) : (
+          <div className="p-4">
+            <ResponsiveContainer width="100%" height={300}>
+              <LineChart data={data.curve} margin={{ top: 8, right: 8, left: 8, bottom: 8 }}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-iv-border" />
+                <XAxis dataKey="soc_pct" tick={{ fontSize: 12 }} className="text-iv-muted" label={{ value: "State of Charge (%)", position: "insideBottom", offset: -5 }} />
+                <YAxis tick={{ fontSize: 12 }} className="text-iv-muted" label={{ value: "Power (kW)", angle: -90, position: "insideLeft" }} />
+                <Tooltip
+                  contentStyle={{ backgroundColor: "var(--iv-bg)", border: "1px solid var(--iv-border)", borderRadius: "8px" }}
+                  labelStyle={{ color: "var(--iv-muted)" }}
+                  formatter={(value: number, name: string) => [value.toFixed(2), name === "avg_power_kw" ? "Avg Power (kW)" : "Max Power (kW)"]}
+                  labelFormatter={(label) => `SoC: ${label}%`}
+                />
+                <Line type="monotone" dataKey="avg_power_kw" stroke="var(--iv-cyan)" strokeWidth={2} dot={false} name="avg_power_kw" />
+                <Line type="monotone" dataKey="max_power_kw" stroke="var(--iv-green)" strokeWidth={2} strokeDasharray="5 5" dot={false} name="max_power_kw" />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/statistics/ChargingCurveDashboard.tsx
+++ b/frontend/src/components/statistics/ChargingCurveDashboard.tsx
@@ -29,11 +29,13 @@ export function ChargingCurveDashboard({ vehicleId }: { vehicleId: string }) {
 
   const fetchData = useCallback(async () => {
     setLoading(true);
+    const controller = new AbortController();
     try {
       // Assuming api.fetchWrapper can be used or just use native fetch if not defined
       const token = localStorage.getItem("access_token");
       const res = await fetch(`/api/v1/vehicles/${vehicleId}/analytics/charging-curve-integrals`, {
-        headers: { Authorization: `Bearer ${token}` }
+        headers: { Authorization: `Bearer ${token}` },
+        signal: controller.signal
       });
       if (res.ok) {
         const json = await res.json();
@@ -41,15 +43,28 @@ export function ChargingCurveDashboard({ vehicleId }: { vehicleId: string }) {
       } else {
         setData(null);
       }
-    } catch {
-      setData(null);
+    } catch (err: any) {
+      if (err.name !== 'AbortError') {
+        setData(null);
+      }
     } finally {
       setLoading(false);
     }
+    
+    return controller;
   }, [vehicleId]);
 
   useEffect(() => {
-    fetchData();
+    let activeController: AbortController | null = null;
+    fetchData().then(controller => {
+      activeController = controller;
+    });
+    
+    return () => {
+      if (activeController) {
+        activeController.abort();
+      }
+    };
   }, [fetchData]);
 
   if (loading) {

--- a/frontend/src/components/statistics/StatisticsShell.tsx
+++ b/frontend/src/components/statistics/StatisticsShell.tsx
@@ -16,6 +16,7 @@ import { MovementDashboard } from "./MovementDashboard";
 import { DrivingStatisticsDashboard } from "./DrivingStatisticsDashboard";
 import { ChargingStatisticsDashboard } from "./ChargingStatisticsDashboard";
 import { MileageKMDashboard } from "./MileageKMDashboard";
+import { ChargingCurveDashboard } from "./ChargingCurveDashboard";
 
 export interface TimelineRange {
   from: Date;
@@ -46,6 +47,7 @@ export function StatisticsShell({ vehicleId }: { vehicleId: string }) {
     { id: "movement", label: "Movement" },
     { id: "driving-stats", label: "Driving Stats" },
     { id: "charging-stats", label: "Charging Stats" },
+    { id: "charging-curve", label: "Charging Curve" },
     { id: "mileage", label: "Mileage" },
   ];
 
@@ -118,6 +120,9 @@ export function StatisticsShell({ vehicleId }: { vehicleId: string }) {
           </Tabs.Content>
           <Tabs.Content value="charging-stats">
             <ChargingStatisticsDashboard vehicleId={vehicleId} dateRange={range} />
+          </Tabs.Content>
+          <Tabs.Content value="charging-curve">
+            <ChargingCurveDashboard vehicleId={vehicleId} />
           </Tabs.Content>
           <Tabs.Content value="mileage">
             <MileageKMDashboard vehicleId={vehicleId} dateRange={range} />


### PR DESCRIPTION
### **User description**
## 📋 Summary

Implements backend endpoint for SoC vs Power_kW and calculates time spent charging 80-100%. Adds frontend visualization with Recharts.
<!-- 🤖 PR Agent will automatically enhance this description with detailed file walkthrough -->
<!-- ⚠️ This section must be filled out (at least 20 characters) for PR validation to pass -->

**Related Issues:** Closes #


---

## 🧩 Type of Change

<!-- Mark the relevant option with an 'x' - At least one must be checked for PR validation -->

- [x] 🆕 New feature (e.g. new dashboard, API endpoint)
- [ ] 🐛 Bug fix
- [ ] ⚙️ Backend change (API, collector, database)
- [ ] 🎨 Frontend change (UI, charts, pages)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

<!-- Mark completed items with an 'x' -->

- [ ] Backend runs and tests pass (if applicable)
- [ ] Frontend builds (`npm run build` in `frontend/`)
- [ ] Manual testing done (if applicable)

---

## 👥 Reviewer Notes

<!-- What should reviewers focus on? Any specific questions or areas of uncertainty? -->


---

## 📌 Additional Context

<!-- Any other context, links to documentation, or important notes -->


___

### **PR Type**
Enhancement


___

### **Description**
- Implements a new backend endpoint for charging curve analytics and time metrics.

- Adds a frontend dashboard component to visualize charging power vs SoC.

- Calculates "wasted time" spent charging between 80% and 100% SoC.

- Integrates the new charging curve view into the statistics shell.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Backend
    API["/charging-curve-integrals"] -- "Queries" --> DB[("ChargingState Table")]
  end
  subgraph Frontend
    Dashboard["ChargingCurveDashboard"] -- "Fetches" --> API
    Dashboard -- "Renders" --> Chart["Recharts LineChart"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.py</strong><dd><code>New backend endpoint for charging curve and time metrics</code>&nbsp; </dd></summary>
<hr>

backend/app/api/v1/analytics.py

<ul><li>Added <code>get_charging_curve_integrals</code> endpoint to calculate average/max <br>power per SoC percentage.<br> <li> Implemented logic to aggregate charging duration, specifically <br>segmenting time spent above and below 80% SoC.<br> <li> Included data validation and capping of duration to handle potential <br>data gaps.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/79/files#diff-1bcd451e46734de2d8e97d41344307998190a3de95c7b5d405ec226041d1cfb3">+85/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ChargingCurveDashboard.tsx</strong><dd><code>New dashboard component for charging curve visualization</code>&nbsp; </dd></summary>
<hr>

frontend/src/components/statistics/ChargingCurveDashboard.tsx

<ul><li>Created a new React component using Recharts to plot the charging <br>power curve.<br> <li> Added metric cards to display "Fast Charging" (0-80%) and "Time <br>Wasted" (80-100%) durations.<br> <li> Implemented data fetching with authentication and loading/error <br>states.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/79/files#diff-2124ebb4668e70a7562d1fa92cd411de434b7a0c999e8eb05b2cd05a15fc5002">+131/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StatisticsShell.tsx</strong><dd><code>Integration of charging curve into statistics shell</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/statistics/StatisticsShell.tsx

<ul><li>Registered the new <code>ChargingCurveDashboard</code> within the statistics tabs.<br> <li> Added a "Charging Curve" navigation item to the statistics shell.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/79/files#diff-d54d4ce1df8218f2c18ff67b47985580386cb2e50b9f414b8a1e5dd7b5bcff42">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

