### PR TITLE
fix(vehicles): remove hardcoded LT country default and ENYAQ WLTP fal…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to the iVDrive project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-04-25
+## [Unreleased] - 2026-04-26
 
 ### Fixed 🐛
-- **Car Overview Charging Power**: Fixed an indexing bug on the Car Overview dashboard where the "Charging Power (now)" metric card was incorrectly displaying the oldest historical value instead of the current real-time charging power.
+- **Vehicle WLTP Fallback Removed**: Removed hardcoded ENYAQ model/trim-based WLTP range fallbacks from `get_overview_wltp`. Now returns `null` when no user-defined or drive-derived WLTP value exists — frontend already handles null gracefully.
+- **Vehicle country_code Default Removed**: Removed hardcoded `"LT"` default from vehicle creation. Country code is now stored as `null` when not provided; analytics endpoints fall back to `"LT"` for fuel/economics queries.
 - **Analytics API Safety & Alignment**: Addressed several PR Agent findings: added safe division checks for speed calculations, prevented negative HVAC penalty outputs, added strict null-checks to frontend metrics, and fully integrated date filtering into the HVAC Isolation endpoint and dashboard.
 - **Elevation API Reliability**: Replaced OpenTopoData external API calls with direct `vehicle_positions.elevation_m` SQL lookups — eliminates HTTP dependency and works reliably inside Docker.
 - **Vampire Drain Calculation**: Fixed broken calculation that used non-existent `BatteryHealth.hv_battery_soc` field. Now correctly uses `ChargingState` with `state=CONNECT_CABLE` intervals, median instead of mean, drain rate capped at 0.15%/hr to exclude driving consumption.

--- a/backend/app/api/v1/vehicles.py
+++ b/backend/app/api/v1/vehicles.py
@@ -194,7 +194,7 @@ async def create_vehicle(
         active_interval_seconds=body.active_interval_seconds,
         parked_interval_seconds=body.parked_interval_seconds,
         wltp_range_km=body.wltp_range_km,
-        country_code=body.country_code or "LT",
+        country_code=body.country_code,
     )
     db.add(vehicle)
     await db.flush()
@@ -1069,21 +1069,6 @@ async def get_overview_wltp(
             return WLTPResponse(wltp_range_km=float(wltp))
         except (TypeError, ValueError):
             pass
-            
-    # 4. Model-based fallbacks
-    model_str = (vehicle.model or "").upper()
-    trim_str = (vehicle.trim_level or "").upper()
-    
-    if "ENYAQ" in model_str:
-        if "80X" in trim_str or "RS" in trim_str or "VRS" in trim_str:
-            wltp = 520.0
-        elif "80" in trim_str:
-            wltp = 540.0
-        elif "60" in trim_str:
-            wltp = 410.0
-        else:
-            wltp = 500.0
-        return WLTPResponse(wltp_range_km=wltp)
 
     return WLTPResponse(wltp_range_km=None)
 


### PR DESCRIPTION


## 📋 Summary

- country_code on vehicle creation now stored as NULL if not provided (analytics.py already falls back to 'LT' for fuel/economics queries)
- Removed ENYAQ model+trim based WLTP hardcoded values from get_overview_wltp (frontend already handles null WLTP gracefully — skips WLTP line in chart)
- Updated CHANGELOG.md
**Related Issues:** Closes #


---

## 🧩 Type of Change

<!-- Mark the relevant option with an 'x' - At least one must be checked for PR validation -->

- [ ] 🆕 New feature (e.g. new dashboard, API endpoint)
- [X] 🐛 Bug fix
- [ ] ⚙️ Backend change (API, collector, database)
- [ ] 🎨 Frontend change (UI, charts, pages)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

<!-- Mark completed items with an 'x' -->

- [ ] Backend runs and tests pass (if applicable)
- [ ] Frontend builds (`npm run build` in `frontend/`)
- [X] Manual testing done (if applicable)

---

## 👥 Reviewer Notes

<!-- What should reviewers focus on? Any specific questions or areas of uncertainty? -->


---

## 📌 Additional Context

<!-- Any other context, links to documentation, or important notes -->
