### PR TITLE
fix: battery_temp undefined in collector.py:956

### DIFF
--- a/backend/app/services/collector.py
+++ b/backend/app/services/collector.py
@@ -956,14 +956,15 @@ class DataCollector:
                 if status_resp and status_resp.overall and status_resp.overall.battery:
                     battery_temp = getattr(status_resp.overall.battery, "temperature", None)
 
-                await _update_or_insert_duration_state(
-                    session, BatteryTemperature, user_vehicle_id,
-                    match_keys={"battery_temperature": battery_temp},
-                    volatile_keys=[],
-                    now=now,
-                    max_gap_s=max_gap_s,
-                    battery_temperature=battery_temp,
-                )
+                if battery_temp is not None:
+                    await _update_or_insert_duration_state(
+                        session, BatteryTemperature, user_vehicle_id,
+                        match_keys={"battery_temperature": battery_temp},
+                        volatile_keys=[],
+                        now=now,
+                        max_gap_s=max_gap_s,
+                        battery_temperature=battery_temp,
+                    )
 
                 # ── Raw API payload archive ─────────────────────────────────
                 # Serialize every response (pydantic → dict) and store as JSONB.

--- a/backend/app/services/collector.py
+++ b/backend/app/services/collector.py
@@ -951,6 +951,11 @@ class DataCollector:
                         outside_temperature=temp_c,
                     )
 
+                # Extract battery temperature from status endpoint
+                battery_temp = None
+                if status_resp and status_resp.overall and status_resp.overall.battery:
+                    battery_temp = getattr(status_resp.overall.battery, "temperature", None)
+
                 await _update_or_insert_duration_state(
                     session, BatteryTemperature, user_vehicle_id,
                     match_keys={"battery_temperature": battery_temp},


### PR DESCRIPTION
### **User description**
## Summary
Fixes `NameError: name 'battery_temp' is not defined` at runtime when writing `BatteryTemperature` records.

## What changed
- Added `battery_temp` extraction from `status_resp.overall.battery.temperature` before the `BatteryTemperature` write block (~line 955).
- Uses the same `getattr` pattern as other battery field extractions in the file.

## Acceptance
- `BatteryTemperature` records written without `NameError`.

Task: 09c28fb9-f5ce-45ab-b3bf-9002d8a66754


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes `NameError` by defining `battery_temp` variable.

- Extracts battery temperature from `status_resp` object safely.

- Uses `getattr` to handle missing battery temperature.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["status_resp"] -- "Extract temperature" --> B["battery_temp variable"]
  B -- "Pass to" --> C["BatteryTemperature record"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>collector.py</strong><dd><code>Define battery_temp before use in duration state update</code>&nbsp; &nbsp; </dd></summary>
<hr>

backend/app/services/collector.py

<ul><li>Added logic to extract <code>battery_temp</code> from the <code>status_resp</code> object before <br>it is used.<br> <li> Implemented null-safe checks for <code>status_resp.overall.battery</code>.<br> <li> Used <code>getattr</code> to safely retrieve the <code>temperature</code> attribute.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/95/files#diff-8a30690d0e5272fc5019ae6ef3cea8a316de8e9eeaf5c905673836c06982d574">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

