### PR TITLE
fix: replace dynamic __import__("sqlalchemy") with top-level text() import

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -536,7 +536,7 @@ async def get_time_budget(
         WHERE user_vehicle_id = :vid
         GROUP BY state
     """
-    vs_result = await db.execute(__import__("sqlalchemy").text(vs_sql), {"vid": str(vehicle_id)})
+    vs_result = await db.execute(text(vs_sql), {"vid": str(vehicle_id)})
     vs_rows = vs_result.fetchall()
 
     state_seconds: dict[str, float] = {}
@@ -549,7 +549,7 @@ async def get_time_budget(
         FROM v_charging_sessions_analytics
         WHERE user_vehicle_id = :vid
     """
-    cs_result = await db.execute(__import__("sqlalchemy").text(cs_sql), {"vid": str(vehicle_id)})
+    cs_result = await db.execute(text(cs_sql), {"vid": str(vehicle_id)})
     charging_seconds = float(cs_result.scalar() or 0)
 
     return {


### PR DESCRIPTION
### **User description**
## Summary
Replaces dynamic `__import__("sqlalchemy").text()` calls with the properly imported `text()` function for static analysis compatibility.

## What changed
- `text` is already imported at line 6: `from sqlalchemy import func, select, text`
- Replaced `__import__("sqlalchemy").text(sql)` → `text(sql)` at former lines 539 and 552.
- File passes `python3 -m py_compile` syntax check.

## Acceptance
- No dynamic `__import__` calls remain in analytics.py.
- File passes Python syntax check.

Task: fc41a90b-1460-4253-ae17-13ae1b4cd871


___

### **PR Type**
Enhancement


___

### **Description**
- Replaced dynamic `__import__` calls with static imports.

- Utilized existing `text()` import from `sqlalchemy`.

- Improved code readability and static analysis compatibility.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph "backend/app/api/v1/analytics.py"
  A["__import__('sqlalchemy').text()"] -- "Refactor to" --> B["text()"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.py</strong><dd><code>Refactor dynamic SQLAlchemy text calls to static imports</code>&nbsp; </dd></summary>
<hr>

backend/app/api/v1/analytics.py

<ul><li>Replaced two instances of <code>__import__("sqlalchemy").text(sql)</code> with the <br>direct call to <code>text(sql)</code>.<br> <li> Leveraged the <code>text</code> function already imported at the top of the module.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/96/files#diff-1bcd451e46734de2d8e97d41344307998190a3de95c7b5d405ec226041d1cfb3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

