### PR TITLE
fix: multiple backend fixes (battery_temp, sqlalchemy text(), asyncio.gather)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the iVDrive project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2026-04-27
+
+### Fixed 🐛
+- **collector.py**: Assign `battery_temp` from `status_resp.overall.battery.temperature` before BatteryTemperature write block; add null guard to skip when None.
+- **analytics.py**: Replace dynamic `__import__('sqlalchemy').text()` calls with the already-imported top-level `text()` function.
+- **telemetry/pipeline.py**: Replace sequential for-await loop in `ingest_batch` with `asyncio.gather()` for concurrent event processing; adds missing telemetry package (`events.py`, `pipeline.py`, `__init__.py`).
+
 ## [Unreleased] - 2026-04-26
 
 ### Fixed 🐛

--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -536,7 +536,7 @@ async def get_time_budget(
         WHERE user_vehicle_id = :vid
         GROUP BY state
     """
-    vs_result = await db.execute(__import__("sqlalchemy").text(vs_sql), {"vid": str(vehicle_id)})
+    vs_result = await db.execute(text(vs_sql), {"vid": str(vehicle_id)})
     vs_rows = vs_result.fetchall()
 
     state_seconds: dict[str, float] = {}
@@ -549,7 +549,7 @@ async def get_time_budget(
         FROM v_charging_sessions_analytics
         WHERE user_vehicle_id = :vid
     """
-    cs_result = await db.execute(__import__("sqlalchemy").text(cs_sql), {"vid": str(vehicle_id)})
+    cs_result = await db.execute(text(cs_sql), {"vid": str(vehicle_id)})
     charging_seconds = float(cs_result.scalar() or 0)
 
     return {

--- a/backend/app/services/collector.py
+++ b/backend/app/services/collector.py
@@ -951,14 +951,20 @@ class DataCollector:
                         outside_temperature=temp_c,
                     )
 
-                await _update_or_insert_duration_state(
-                    session, BatteryTemperature, user_vehicle_id,
-                    match_keys={"battery_temperature": battery_temp},
-                    volatile_keys=[],
-                    now=now,
-                    max_gap_s=max_gap_s,
-                    battery_temperature=battery_temp,
-                )
+                # Extract battery temperature from status endpoint
+                battery_temp = None
+                if status_resp and status_resp.overall and status_resp.overall.battery:
+                    battery_temp = getattr(status_resp.overall.battery, "temperature", None)
+
+                if battery_temp is not None:
+                    await _update_or_insert_duration_state(
+                        session, BatteryTemperature, user_vehicle_id,
+                        match_keys={"battery_temperature": battery_temp},
+                        volatile_keys=[],
+                        now=now,
+                        max_gap_s=max_gap_s,
+                        battery_temperature=battery_temp,
+                    )
 
                 # ── Raw API payload archive ─────────────────────────────────
                 # Serialize every response (pydantic → dict) and store as JSONB.

--- a/backend/app/services/telemetry/__init__.py
+++ b/backend/app/services/telemetry/__init__.py
@@ -1,0 +1,34 @@
+"""Real-time telemetry ingestion pipeline.
+
+This package provides:
+- Pydantic event models for vehicle telemetry (location, speed, battery, HVAC)
+- An ingestion pipeline that validates and stores telemetry events in the DB
+"""
+
+from app.services.telemetry.events import (
+    TelemetryEvent,
+    LocationEvent,
+    SpeedEvent,
+    BatteryEvent,
+    HVACEvent,
+    ConnectionEvent,
+    TripStartEvent,
+    TripEndEvent,
+    ChargeStartEvent,
+    ChargeEndEvent,
+)
+from app.services.telemetry.pipeline import TelemetryPipeline
+
+__all__ = [
+    "TelemetryEvent",
+    "LocationEvent",
+    "SpeedEvent",
+    "BatteryEvent",
+    "HVACEvent",
+    "ConnectionEvent",
+    "TripStartEvent",
+    "TripEndEvent",
+    "ChargeStartEvent",
+    "ChargeEndEvent",
+    "TelemetryPipeline",
+]

--- a/backend/app/services/telemetry/events.py
+++ b/backend/app/services/telemetry/events.py
@@ -1,0 +1,211 @@
+"""Pydantic event models for vehicle telemetry.
+
+Each event type corresponds to a specific data stream from the vehicle.
+Models are designed to be validated at ingestion time and then mapped
+to SQLAlchemy ORM models for persistence.
+"""
+
+from datetime import datetime, UTC
+from enum import Enum
+from typing import Annotated, Any
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class EventSource(str, Enum):
+    """Origin of the telemetry event."""
+
+    CONNECTION_STATUS = "connection_status"
+    CHARGING_STATUS = "charging_status"
+    VEHICLE_STATUS = "vehicle_status"
+    POSITION = "position"
+    AIR_CONDITIONING = "air_conditioning"
+    MAINTENANCE = "maintenance"
+    DRIVING_RANGE = "driving_range"
+    MANUAL = "manual"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Base event
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TelemetryEvent(BaseModel):
+    """Base class for all telemetry events."""
+
+    user_vehicle_id: str = Field(..., description="UUID of the UserVehicle")
+    captured_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    source: EventSource = Field(default=EventSource.CONNECTION_STATUS)
+
+    model_config = {"from_attributes": True}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Location
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class LocationEvent(TelemetryEvent):
+    """GPS position event."""
+
+    source: EventSource = EventSource.POSITION
+    latitude: float = Field(..., ge=-90, le=90)
+    longitude: float = Field(..., ge=-180, le=180)
+    altitude_m: float | None = None
+    heading_deg: float | None = Field(default=None, ge=0, le=360)
+    speed_kmh: float | None = Field(default=None, ge=0)
+    accuracy_m: float | None = None
+    outside_temp_celsius: float | None = None
+    weather_condition: str | None = None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Speed / Motion
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class SpeedEvent(TelemetryEvent):
+    """Vehicle speed and motion state event."""
+
+    source: EventSource = EventSource.VEHICLE_STATUS
+    speed_kmh: float | None = Field(default=None, ge=0)
+    odometer_km: float | None = Field(default=None, ge=0)
+    in_motion: bool = False
+    ignition_on: bool = False
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Battery
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class BatteryEvent(TelemetryEvent):
+    """High-voltage battery status event."""
+
+    source: EventSource = EventSource.CHARGING_STATUS
+    battery_pct: int = Field(..., ge=0, le=100)
+    remaining_range_m: int | None = None
+    charging: bool = False
+    charge_power_kw: float | None = Field(default=None, ge=0)
+    charge_rate_km_per_hour: float | None = None
+    remaining_time_min: int | None = None
+    target_soc_pct: int | None = Field(default=None, ge=0, le=100)
+    battery_temp_celsius: float | None = None
+    hv_voltage: float | None = None
+    hv_current: float | None = None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# HVAC
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class HVACEvent(TelemetryEvent):
+    """Heating, ventilation and air conditioning event."""
+
+    source: EventSource = EventSource.AIR_CONDITIONING
+    hvac_state: str | None = None  # "ON", "OFF", "HEATING", "COOLING", "VENTILATION"
+    target_temp_celsius: float | None = None
+    outside_temp_celsius: float | None = None
+    seat_heating_front_left: bool | None = None
+    seat_heating_front_right: bool | None = None
+    window_heating_enabled: bool | None = None
+    steering_wheel_position: str | None = None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Connection / Online state
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class ConnectionEvent(TelemetryEvent):
+    """Vehicle online/offline status event."""
+
+    source: EventSource = EventSource.CONNECTION_STATUS
+    is_online: bool = False
+    is_charging: bool = False
+    is_climatizing: bool = False
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# State machine events — derived from basic telemetry
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TripStartEvent(TelemetryEvent):
+    """Emitted when a trip start is detected (motion begins)."""
+
+    source: EventSource = EventSource.VEHICLE_STATUS
+    latitude: float | None = None
+    longitude: float | None = None
+    odometer_km: float | None = None
+    soc_pct: int | None = None
+
+
+class TripEndEvent(TelemetryEvent):
+    """Emitted when a trip end is detected (motion stops)."""
+
+    source: EventSource = EventSource.VEHICLE_STATUS
+    latitude: float | None = None
+    longitude: float | None = None
+    odometer_km: float | None = None
+    soc_pct: int | None = None
+    distance_km: float | None = None
+    duration_seconds: int | None = None
+
+
+class ChargeStartEvent(TelemetryEvent):
+    """Emitted when a charging session start is detected."""
+
+    source: EventSource = EventSource.CHARGING_STATUS
+    latitude: float | None = None
+    longitude: float | None = None
+    soc_pct: int | None = None
+    charge_type: str | None = None
+    charge_power_kw: float | None = None
+
+
+class ChargeEndEvent(TelemetryEvent):
+    """Emitted when a charging session end is detected."""
+
+    source: EventSource = EventSource.CHARGING_STATUS
+    latitude: float | None = None
+    longitude: float | None = None
+    soc_pct: int | None = None
+    energy_kwh: float | None = None
+    duration_seconds: int | None = None
+    cost_eur: float | None = None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Raw ingestion envelope — accepts any validated event as JSON
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TelemetryEnvelope(BaseModel):
+    """Top-level envelope for raw telemetry ingestion via HTTP/WebSocket."""
+
+    events: list[dict[str, Any]] = Field(..., description="List of raw event dicts")
+
+    @model_validator(mode="after")
+    def validate_events(self) -> "TelemetryEnvelope":
+        """Parse and validate each raw event dict against the appropriate model."""
+        validated = []
+        for raw in self.events:
+            source = raw.get("source", "connection_status")
+            try:
+                if source == "position":
+                    validated.append(LocationEvent.model_validate(raw))
+                elif source in ("charging_status",):
+                    validated.append(BatteryEvent.model_validate(raw))
+                elif source == "air_conditioning":
+                    validated.append(HVACEvent.model_validate(raw))
+                elif source == "vehicle_status":
+                    validated.append(SpeedEvent.model_validate(raw))
+                elif source == "connection_status":
+                    validated.append(ConnectionEvent.model_validate(raw))
+                else:
+                    validated.append(TelemetryEvent.model_validate(raw))
+            except Exception as exc:
+                raise ValueError(f"Failed to validate event: {raw}") from exc
+        self.events = validated  # type: ignore[assignment]
+        return self

--- a/backend/app/services/telemetry/pipeline.py
+++ b/backend/app/services/telemetry/pipeline.py
@@ -1,0 +1,349 @@
+"""Real-time telemetry ingestion pipeline.
+
+Provides a single TelemetryPipeline class that:
+1. Validates incoming TelemetryEvent objects
+2. Maps them to SQLAlchemy ORM models
+3. Commits them to the database with retry / error isolation
+
+Designed to be called by:
+- The DataCollector after each API fetch cycle
+- WebSocket / HTTP ingestion endpoints
+- The state machine when deriving high-level events
+"""
+
+import asyncio
+import logging
+from datetime import datetime, UTC
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select, update
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.database import async_session
+from app.models.telemetry import (
+    VehiclePosition,
+    ConnectionState,
+    ChargingState,
+    VehicleState,
+    AirConditioningState,
+    BatteryHealth,
+    PowerUsage,
+    ChargingCurve,
+    Trip,
+    ChargingSession,
+)
+from app.models.vehicle import UserVehicle
+from app.services.telemetry.events import (
+    LocationEvent,
+    SpeedEvent,
+    BatteryEvent,
+    HVACEvent,
+    ConnectionEvent,
+    TelemetryEvent,
+    TripStartEvent,
+    TripEndEvent,
+    ChargeStartEvent,
+    ChargeEndEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TelemetryPipeline:
+    """Ingestion pipeline that validates and stores telemetry events.
+
+    All events for a given vehicle are committed in a single transaction.
+    Failures are isolated — one bad event does not roll back others.
+    """
+
+    def __init__(self) -> None:
+        self._error_count = 0
+        self._last_error: str | None = None
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Public API
+    # ─────────────────────────────────────────────────────────────────────────
+
+    async def ingest(self, event: TelemetryEvent) -> bool:
+        """Ingest a single telemetry event.
+
+        Returns True on success, False on validation/storage failure.
+        """
+        try:
+            await self._store_event(event)
+            return True
+        except Exception as exc:
+            self._error_count += 1
+            self._last_error = str(exc)
+            logger.warning("TelemetryPipeline: failed to store event %s — %s", event.source, exc)
+            return False
+
+    async def ingest_batch(self, events: list[TelemetryEvent]) -> dict[str, Any]:
+        """Ingest a list of telemetry events concurrently.
+
+        Returns a summary dict with success/failure counts.
+        """
+        if not events:
+            return {"total": 0, "success": 0, "failed": 0}
+
+        results = await asyncio.gather(*[self.ingest(event) for event in events])
+        success = sum(1 for r in results if r)
+        return {"total": len(events), "success": success, "failed": len(events) - success}
+
+    def stats(self) -> dict[str, Any]:
+        """Return pipeline error statistics."""
+        return {
+            "error_count": self._error_count,
+            "last_error": self._last_error,
+        }
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Internal store helpers
+    # ─────────────────────────────────────────────────────────────────────────
+
+    async def _store_event(self, event: TelemetryEvent) -> None:
+        """Route event to the appropriate storage handler."""
+        if isinstance(event, LocationEvent):
+            await self._store_location(event)
+        elif isinstance(event, SpeedEvent):
+            await self._store_speed(event)
+        elif isinstance(event, BatteryEvent):
+            await self._store_battery(event)
+        elif isinstance(event, HVACEvent):
+            await self._store_hvac(event)
+        elif isinstance(event, ConnectionEvent):
+            await self._store_connection(event)
+        elif isinstance(event, TripStartEvent):
+            await self._store_trip_start(event)
+        elif isinstance(event, TripEndEvent):
+            await self._store_trip_end(event)
+        elif isinstance(event, ChargeStartEvent):
+            await self._store_charge_start(event)
+        elif isinstance(event, ChargeEndEvent):
+            await self._store_charge_end(event)
+        else:
+            logger.debug("TelemetryPipeline: unhandled event type %s", type(event).__name__)
+
+    async def _store_location(self, event: LocationEvent) -> None:
+        """Store a VehiclePosition record."""
+        async with async_session() as session:
+            try:
+                session.add(
+                    VehiclePosition(
+                        user_vehicle_id=UUID(event.user_vehicle_id),
+                        captured_at=event.captured_at,
+                        latitude=event.latitude,
+                        longitude=event.longitude,
+                        elevation_m=event.altitude_m,
+                        outside_temp_celsius=event.outside_temp_celsius,
+                        weather_condition=event.weather_condition,
+                    )
+                )
+                await session.commit()
+            except SQLAlchemyError:
+                await session.rollback()
+                raise
+
+    async def _store_speed(self, event: SpeedEvent) -> None:
+        """Store/update ConnectionState with motion data."""
+        async with async_session() as session:
+            try:
+                session.add(
+                    ConnectionState(
+                        user_vehicle_id=UUID(event.user_vehicle_id),
+                        captured_at=event.captured_at,
+                        is_online=True,
+                        in_motion=event.in_motion,
+                        ignition_on=event.ignition_on,
+                    )
+                )
+                await session.commit()
+            except SQLAlchemyError:
+                await session.rollback()
+                raise
+
+    async def _store_battery(self, event: BatteryEvent) -> None:
+        """Store battery health + charging state.
+
+        Creates a BatteryHealth record and a ChargingState record
+        when the vehicle is actively charging.
+        """
+        async with async_session() as session:
+            try:
+                session.add(
+                    BatteryHealth(
+                        user_vehicle_id=UUID(event.user_vehicle_id),
+                        captured_at=event.captured_at,
+                        hv_battery_voltage=event.hv_voltage,
+                        hv_battery_current=event.hv_current,
+                        hv_battery_temperature=event.battery_temp_celsius,
+                    )
+                )
+                if event.charging:
+                    session.add(
+                        ChargingState(
+                            user_vehicle_id=UUID(event.user_vehicle_id),
+                            first_date=event.captured_at,
+                            last_date=event.captured_at,
+                            state="CHARGING",
+                            battery_pct=event.battery_pct,
+                            remaining_range_m=event.remaining_range_m,
+                            charge_power_kw=event.charge_power_kw,
+                            charge_rate_km_per_hour=event.charge_rate_km_per_hour,
+                            remaining_time_min=event.remaining_time_min,
+                            target_soc_pct=event.target_soc_pct,
+                        )
+                    )
+                await session.commit()
+            except SQLAlchemyError:
+                await session.rollback()
+                raise
+
+    async def _store_hvac(self, event: HVACEvent) -> None:
+        """Store an AirConditioningState record."""
+        async with async_session() as session:
+            try:
+                session.add(
+                    AirConditioningState(
+                        user_vehicle_id=UUID(event.user_vehicle_id),
+                        captured_at=event.captured_at,
+                        state=event.hvac_state,
+                        target_temp_celsius=event.target_temp_celsius,
+                        outside_temp_celsius=event.outside_temp_celsius,
+                        seat_heating_front_left=event.seat_heating_front_left,
+                        seat_heating_front_right=event.seat_heating_front_right,
+                        window_heating_enabled=event.window_heating_enabled,
+                        steering_wheel_position=event.steering_wheel_position,
+                    )
+                )
+                await session.commit()
+            except SQLAlchemyError:
+                await session.rollback()
+                raise
+
+    async def _store_connection(self, event: ConnectionEvent) -> None:
+        """Store a ConnectionState record (online/offline detection)."""
+        async with async_session() as session:
+            try:
+                session.add(
+                    ConnectionState(
+                        user_vehicle_id=UUID(event.user_vehicle_id),
+                        captured_at=event.captured_at,
+                        is_online=event.is_online,
+                        in_motion=False,
+                        ignition_on=False,
+                    )
+                )
+                await session.commit()
+            except SQLAlchemyError:
+                await session.rollback()
+                raise
+
+    # ─── State machine derived events ─────────────────────────────────────
+
+    async def _store_trip_start(self, event: TripStartEvent) -> None:
+        """Begin a new Trip record."""
+        async with async_session() as session:
+            try:
+                session.add(
+                    Trip(
+                        user_vehicle_id=UUID(event.user_vehicle_id),
+                        start_date=event.captured_at,
+                        start_lat=event.latitude,
+                        start_lon=event.longitude,
+                        start_odometer=event.odometer_km,
+                        start_soc=event.soc_pct,
+                    )
+                )
+                await session.commit()
+            except SQLAlchemyError:
+                await session.rollback()
+                raise
+
+    async def _store_trip_end(self, event: TripEndEvent) -> None:
+        """Close the most recent open Trip record."""
+        async with async_session() as session:
+            try:
+                result = await session.execute(
+                    select(Trip)
+                    .where(
+                        Trip.user_vehicle_id == UUID(event.user_vehicle_id),
+                        Trip.end_date.is_(None),
+                    )
+                    .order_by(Trip.start_date.desc())
+                    .limit(1)
+                )
+                trip = result.scalar_one_or_none()
+                if trip:
+                    trip.end_date = event.captured_at
+                    trip.end_lat = event.latitude
+                    trip.end_lon = event.longitude
+                    trip.end_odometer = event.odometer_km
+                    trip.end_soc = event.soc_pct
+                    if (
+                        trip.start_odometer is not None
+                        and event.odometer_km is not None
+                    ):
+                        trip.distance_km = event.odometer_km - trip.start_odometer
+                    await session.commit()
+                else:
+                    logger.debug(
+                        "TelemetryPipeline: no open trip to close for vehicle %s",
+                        event.user_vehicle_id,
+                    )
+            except SQLAlchemyError:
+                await session.rollback()
+                raise
+
+    async def _store_charge_start(self, event: ChargeStartEvent) -> None:
+        """Begin a new ChargingSession record."""
+        async with async_session() as session:
+            try:
+                session.add(
+                    ChargingSession(
+                        user_vehicle_id=UUID(event.user_vehicle_id),
+                        session_start=event.captured_at,
+                        latitude=event.latitude,
+                        longitude=event.longitude,
+                        start_level=event.soc_pct,
+                        charging_type=event.charge_type,
+                    )
+                )
+                await session.commit()
+            except SQLAlchemyError:
+                await session.rollback()
+                raise
+
+    async def _store_charge_end(self, event: ChargeEndEvent) -> None:
+        """Close the most recent open ChargingSession record."""
+        async with async_session() as session:
+            try:
+                result = await session.execute(
+                    select(ChargingSession)
+                    .where(
+                        ChargingSession.user_vehicle_id == UUID(event.user_vehicle_id),
+                        ChargingSession.session_end.is_(None),
+                    )
+                    .order_by(ChargingSession.session_start.desc())
+                    .limit(1)
+                )
+                session_obj = result.scalar_one_or_none()
+                if session_obj:
+                    session_obj.session_end = event.captured_at
+                    session_obj.end_level = event.soc_pct
+                    session_obj.energy_kwh = event.energy_kwh
+                    session_obj.actual_cost_eur = event.cost_eur
+                    await session.commit()
+                else:
+                    logger.debug(
+                        "TelemetryPipeline: no open charging session to close for vehicle %s",
+                        event.user_vehicle_id,
+                    )
+            except SQLAlchemyError:
+                await session.rollback()
+                raise
+
+
+# Singleton pipeline instance — imported by collector and state machine
+pipeline = TelemetryPipeline()


### PR DESCRIPTION
### **User description**
## 📋 Summary

Consolidated fix for 3 collector/backend issues:

1. **collector.py**: Assign battery_temp from status_resp.overall.battery.temperature before BatteryTemperature write block; add null guard to skip when None
2. **analytics.py**: Replace dynamic __import__('sqlalchemy').text() calls with the already-imported top-level text() function
3. **telemetry/pipeline.py**: Replace sequential for-await loop in ingest_batch with asyncio.gather() for concurrent event processing; adds missing telemetry package (events.py, pipeline.py, __init__.py)

**Related Issues:** Closes #

---

## 🧩 Type of Change

- [ ] 🆕 New feature
- [x] 🐛 Bug fix
- [x] ⚙️ Backend change
- [ ] 🎨 Frontend change
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

## ✅ Validation

- [ ] Backend runs and tests pass
- [ ] Frontend builds
- [ ] Manual testing done

## 👥 Reviewer Notes

Consolidated from Tasks: 09c28fb9, fc41a90b, d04c2970

## 📌 Additional Context

All 3 bugfixes from separate PRs merged into one.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed battery temperature extraction in `collector.py` with proper null safety.

- Optimized `analytics.py` by using the imported `text()` function instead of dynamic imports.

- Improved telemetry ingestion performance using `asyncio.gather` for concurrent processing.

- Introduced a new telemetry package with Pydantic models and a persistence pipeline.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Telemetry
    E["Events (Pydantic)"] -- "Validated" --> P["Pipeline"]
    P -- "asyncio.gather" --> DB[("SQLAlchemy DB")]
  end
  subgraph Collector
    C["Data Collector"] -- "Safe Extract" --> BT["Battery Temp"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.py</strong><dd><code>Refactor SQLAlchemy text usage for efficiency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/api/v1/analytics.py

<ul><li>Replaced dynamic <code>__import__("sqlalchemy").text()</code> calls with the <br>pre-imported <code>text()</code> function.<br> <li> Cleaned up SQL execution logic for vehicle state and charging <br>durations.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/99/files#diff-1bcd451e46734de2d8e97d41344307998190a3de95c7b5d405ec226041d1cfb3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Initialize telemetry service package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/services/telemetry/__init__.py

<ul><li>Initialized the telemetry package.<br> <li> Exported key event models and the <code>TelemetryPipeline</code> class for external <br>use.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/99/files#diff-7268ec632731afda4cb3a565b09bc8c02685ffbf2d34685e35b76c0a738c8fd7">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>events.py</strong><dd><code>Define telemetry event models and validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/services/telemetry/events.py

<ul><li>Defined Pydantic models for various telemetry events (Location, <br>Battery, HVAC, etc.).<br> <li> Implemented a <code>TelemetryEnvelope</code> with a model validator to handle <br>polymorphic event ingestion.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/99/files#diff-c4dd8010322a45d63e7823b01fa32ce6927d73b30cd50e443cba146a3c1ec928">+211/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pipeline.py</strong><dd><code>Implement concurrent telemetry ingestion pipeline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/services/telemetry/pipeline.py

<ul><li>Implemented <code>TelemetryPipeline</code> to map events to SQLAlchemy ORM models.<br> <li> Updated <code>ingest_batch</code> to use <code>asyncio.gather</code> for concurrent event <br>processing.<br> <li> Added specific handlers for storing location, speed, battery, and <br>state-machine events.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/99/files#diff-737bc29a15a5e1c5655edc888de6d76e50af6e1c10a66e273f7d6deaeb01c8da">+349/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>collector.py</strong><dd><code>Fix battery temperature extraction and null handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/services/collector.py

<ul><li>Added logic to safely extract <code>battery_temp</code> from the status response <br>object.<br> <li> Implemented a null guard to prevent database writes when battery <br>temperature is unavailable.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/99/files#diff-8a30690d0e5272fc5019ae6ef3cea8a316de8e9eeaf5c905673836c06982d574">+14/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with recent backend fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Documented fixes for the collector, analytics, and telemetry pipeline.<br> <li> Noted the addition of the new telemetry package.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/99/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

