### PR TITLE
fix: _store_trip_end selects oldest trip; add Query bounds on limit params

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -102,7 +102,7 @@ async def get_charging_sessions(
     vehicle_id: UUID,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
-    limit: int = 20
+    limit: int = Query(default=20, ge=1, le=10000)
 ):
     """List recent charging sessions for the UI."""
     await get_user_vehicle(user.id, vehicle_id, db)
@@ -229,7 +229,7 @@ async def get_battery_health(
     vehicle_id: UUID,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
-    limit: int = 100
+    limit: int = Query(default=100, ge=1, le=10000)
 ):
     """Return the latest battery health metrics including 12V and cell voltages."""
     await get_user_vehicle(user.id, vehicle_id, db)
@@ -268,7 +268,7 @@ async def get_power_usage(
     vehicle_id: UUID,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
-    limit: int = 100
+    limit: int = Query(default=100, ge=1, le=10000)
 ):
     """Return detailed power consumption breakdown over time."""
     await get_user_vehicle(user.id, vehicle_id, db)
@@ -299,7 +299,7 @@ async def get_charging_curves(
     vehicle_id: UUID,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
-    limit: int = 100
+    limit: int = Query(default=100, ge=1, le=10000)
 ):
     """Return charging curve points (power/voltage vs SoC)."""
     await get_user_vehicle(user.id, vehicle_id, db)
@@ -332,7 +332,7 @@ async def get_legacy_charging_power_curve(
     vehicle_id: UUID,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
-    limit: int = 500
+    limit: int = Query(default=500, ge=1, le=10000)
 ):
     """Query 41 & 51: Real-time charging power curve."""
     await get_user_vehicle(user.id, vehicle_id, db)

--- a/backend/app/services/telemetry/pipeline.py
+++ b/backend/app/services/telemetry/pipeline.py
@@ -271,7 +271,7 @@ class TelemetryPipeline:
                         Trip.user_vehicle_id == UUID(event.user_vehicle_id),
                         Trip.end_date.is_(None),
                     )
-                    .order_by(Trip.start_date.desc())
+                    .order_by(Trip.start_date.asc())
                     .limit(1)
                 )
                 trip = result.scalar_one_or_none()


### PR DESCRIPTION
### **User description**
## 📋 Summary

Two critical fixes:

1. **_store_trip_end logic bug**: Changed order_by(Trip.start_date.desc()) → .asc() to close the OLDEST open trip first (FIFO), not the newest. Previously the most recent trip was being finalized instead of the oldest, causing data correctness issues.

2. **Unbounded limit params (DoS risk)**: Added Query(ge=1, le=10000) bounds to limit parameters in:
  - get_battery_health (was 100, now 1-10000)
  - get_power_usage (was 100, now 1-10000)
  - get_charging_curves (was 100, now 1-10000)
  - get_legacy_charging_power_curve (was 500, now 1-10000)
  - get_charging_sessions (was 20, now 1-10000)

Tasks: _store_trip_end bug, Unbounded limit param

**Related Issues:** Closes #


---

## 🧩 Type of Change

<!-- Mark the relevant option with an 'x' - At least one must be checked for PR validation -->

- [ ] 🆕 New feature (e.g. new dashboard, API endpoint)
- [ ] 🐛 Bug fix
- [x] ⚙️ Backend change (API, collector, database)
- [ ] 🎨 Frontend change (UI, charts, pages)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

<!-- Mark completed items with an 'x' -->

- [ ] Backend runs and tests pass (if applicable)
- [ ] Frontend builds (`npm run build` in `frontend/`)
- [ ] Manual testing done (if applicable)

---

## 👥 Reviewer Notes

<!-- What should reviewers focus on? Any specific questions or areas of uncertainty? -->


---

## 📌 Additional Context

<!-- Any other context, links to documentation, or important notes -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes trip finalization logic to close the oldest open trip first.

- Implements validation bounds for limit parameters in analytics endpoints.

- Prevents potential DoS by capping query results to 10,000 records.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph "Telemetry Service"
    A["_store_trip_end"] -- "Change sort to ASC" --> B["Close Oldest Trip"]
  end
  subgraph "Analytics API"
    C["API Endpoints"] -- "Add Query(ge=1, le=10000)" --> D["Input Validation"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.py</strong><dd><code>Add validation bounds to analytics query limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/api/v1/analytics.py

<ul><li>Added <code>Query</code> validation to the <code>limit</code> parameter in multiple endpoints: <br><code>get_charging_sessions</code>, <code>get_battery_health</code>, <code>get_power_usage</code>, <br><code>get_charging_curves</code>, and <code>get_legacy_charging_power_curve</code>.<br> <li> Set a minimum value of 1 and a maximum value of 10,000 for these <br>parameters to ensure API stability.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/100/files#diff-1bcd451e46734de2d8e97d41344307998190a3de95c7b5d405ec226041d1cfb3">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pipeline.py</strong><dd><code>Fix trip closing logic to target oldest record</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/services/telemetry/pipeline.py

<ul><li>Modified the <code>_store_trip_end</code> method to order open trips by <code>start_date</code> <br>in ascending order instead of descending.<br> <li> This ensures that the oldest open trip is closed first (FIFO) when a <br>trip end event is processed.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/100/files#diff-737bc29a15a5e1c5655edc888de6d76e50af6e1c10a66e273f7d6deaeb01c8da">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

