### PR TITLE
feat(analytics+frontend): Charging Curve Integrals — kW vs SoC chart + wasted-time callout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - 2026-04-27
 
+### Added 🆕
+- **analytics.py**: `GET /analytics/charging-curve-integrals-v2` now accepts optional `session_id` query param to filter charging curves by specific charging session.
+- **analytics.py**: `charging-curve-integrals-v2` now computes actual charging durations per SoC bracket using `min/max(captured_at)` timestamps instead of the 5-min sampling estimate.
+
 ### Fixed 🐛
 - **collector.py**: Assign `battery_temp` from `status_resp.overall.battery.temperature` before BatteryTemperature write block; add null guard to skip when None.
 - **analytics.py**: Replace dynamic `__import__('sqlalchemy').text()` calls with the already-imported top-level `text()` function.

--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -903,6 +903,7 @@ async def get_hvac_isolation(
 @router.get("/{vehicle_id}/analytics/charging-curve-integrals-v2")
 async def get_charging_curve_integrals_v2(
     vehicle_id: UUID,
+    session_id: int | None = Query(None, description="Filter by specific charging session ID"),
     from_date: datetime | None = Query(None),
     to_date: datetime | None = Query(None),
     db: AsyncSession = Depends(get_db),
@@ -911,8 +912,18 @@ async def get_charging_curve_integrals_v2(
     """
     Plot Charging Power (kW) over SoC (%) and calculate the 'wasted time'
     (time spent charging from 80% to 100%). Uses charging_curves table.
+    Optionally filter by specific charging session via session_id.
     """
     await get_user_vehicle(user.id, vehicle_id, db)
+
+    # Build base filter conditions
+    base_where = [
+        ChargingCurve.user_vehicle_id == vehicle_id,
+        ChargingCurve.power_kw.is_not(None),
+        ChargingCurve.soc_pct.is_not(None),
+    ]
+    if session_id is not None:
+        base_where.append(ChargingCurve.session_id == session_id)
 
     # Curve data: Average Power kW per SoC %
     stmt_curve = (
@@ -922,18 +933,15 @@ async def get_charging_curve_integrals_v2(
             func.max(ChargingCurve.power_kw).label("max_power"),
             func.count(ChargingCurve.id).label("samples")
         )
-        .where(
-            ChargingCurve.user_vehicle_id == vehicle_id,
-            ChargingCurve.power_kw.is_not(None),
-            ChargingCurve.soc_pct.is_not(None)
-        )
+        .where(*base_where)
+        .group_by(ChargingCurve.soc_pct)
+        .order_by(ChargingCurve.soc_pct)
     )
     if from_date:
         stmt_curve = stmt_curve.where(ChargingCurve.captured_at >= from_date)
     if to_date:
         stmt_curve = stmt_curve.where(ChargingCurve.captured_at <= to_date)
 
-    stmt_curve = stmt_curve.group_by(ChargingCurve.soc_pct).order_by(ChargingCurve.soc_pct)
     result_curve = await db.execute(stmt_curve)
     curve_data = result_curve.all()
 
@@ -953,19 +961,13 @@ async def get_charging_curve_integrals_v2(
             func.floor(ChargingCurve.soc_pct / 20).label("bracket"),
             func.count(ChargingCurve.id).label("count"),
             func.avg(ChargingCurve.power_kw).label("avg_power"),
+            func.min(ChargingCurve.captured_at).label("min_time"),
+            func.max(ChargingCurve.captured_at).label("max_time"),
         )
-        .where(
-            ChargingCurve.user_vehicle_id == vehicle_id,
-            ChargingCurve.power_kw.is_not(None),
-            ChargingCurve.soc_pct.is_not(None)
-        )
+        .where(*base_where)
+        .group_by("bracket")
+        .order_by("bracket")
     )
-    if from_date:
-        stmt_brackets = stmt_brackets.where(ChargingCurve.captured_at >= from_date)
-    if to_date:
-        stmt_brackets = stmt_brackets.where(ChargingCurve.captured_at <= to_date)
-
-    stmt_brackets = stmt_brackets.group_by("bracket").order_by("bracket")
     res_brackets = await db.execute(stmt_brackets)
 
     bracket_map = {row.bracket: row for row in res_brackets.all()}
@@ -977,18 +979,41 @@ async def get_charging_curve_integrals_v2(
         {"label": "80-100%", "key": 3.0, "energy_kwh": 0.0, "minutes": 0, "samples": 0},
     ]
 
-    # Estimate: 5-min sampling interval
+    # Estimate: 5-min sampling interval fallback; use actual time when min/max are available
     for bd in bracket_defs:
         row = bracket_map.get(bd["key"])
         if row:
             avg_p = float(row.avg_power) if row.avg_power else 0
             count = row.count or 0
             bd["energy_kwh"] = round(avg_p * count / 12, 2)
-            bd["minutes"] = round(count * 5)
+            # Try to compute actual duration from timestamps
+            if row.min_time and row.max_time and hasattr(row.min_time, 'total_seconds'):
+                min_t = row.min_time
+                max_t = row.max_time
+                if min_t.tzinfo is not None and max_t.tzinfo is None:
+                    max_t = max_t.replace(tzinfo=min_t.tzinfo)
+                elif min_t.tzinfo is None and max_t.tzinfo is not None:
+                    min_t = min_t.replace(tzinfo=max_t.tzinfo)
+                actual_minutes = (max_t - min_t).total_seconds() / 60.0
+                if actual_minutes > 0:
+                    bd["minutes"] = round(actual_minutes)
+                else:
+                    bd["minutes"] = round(count * 5)
+            else:
+                bd["minutes"] = round(count * 5)
             bd["samples"] = count
 
     wasted_row = bracket_map.get(3.0)
-    wasted_minutes = round(wasted_row.count * 5) if wasted_row and wasted_row.count else 0
+    if wasted_row and hasattr(wasted_row, 'min_time') and wasted_row.min_time and wasted_row.max_time:
+        min_t = wasted_row.min_time
+        max_t = wasted_row.max_time
+        if min_t.tzinfo is not None and max_t.tzinfo is None:
+            max_t = max_t.replace(tzinfo=min_t.tzinfo)
+        elif min_t.tzinfo is None and max_t.tzinfo is not None:
+            min_t = min_t.replace(tzinfo=max_t.tzinfo)
+        wasted_minutes = round((max_t - min_t).total_seconds() / 60.0)
+    else:
+        wasted_minutes = round(wasted_row.count * 5) if wasted_row and wasted_row.count else 0
 
     total_energy = sum(b["energy_kwh"] for b in bracket_defs)
     total_minutes = sum(b["minutes"] for b in bracket_defs)

--- a/frontend/src/components/statistics/ChargingCurveIntegralsDashboard.tsx
+++ b/frontend/src/components/statistics/ChargingCurveIntegralsDashboard.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { api } from "@/lib/api";
-import { Loader2, Zap } from "lucide-react";
+import { Loader2, Zap, Clock, BatteryWarning } from "lucide-react";
 import {
   BarChart,
   Bar,
@@ -12,7 +12,8 @@ import {
   Tooltip,
   Legend,
   ResponsiveContainer,
-  Cell,
+  LineChart,
+  Line,
 } from "recharts";
 
 interface BracketData {
@@ -66,7 +67,7 @@ export function ChargingCurveIntegralsDashboard({ vehicleId, dateRange }: { vehi
     );
   }
 
-  if (!data || data.brackets.length === 0) {
+  if (!data || data.curve.length === 0) {
     return (
       <div className="glass rounded-2xl border border-iv-border p-6 mt-6">
         <div className="flex items-center gap-2 mb-2">
@@ -84,7 +85,8 @@ export function ChargingCurveIntegralsDashboard({ vehicleId, dateRange }: { vehi
     "Time (min)": b.minutes,
   }));
 
-  const COLORS = ["#3b82f6", "#22c55e", "#eab308", "#ef4444"];
+  const wastedMinutes = data.wasted_minutes_80_100;
+  const wastedPct = data.wasted_pct;
 
   return (
     <div className="space-y-6 mt-6">
@@ -93,14 +95,52 @@ export function ChargingCurveIntegralsDashboard({ vehicleId, dateRange }: { vehi
         {[
           { label: "Total Energy", value: `${data.total_energy_kwh} kWh`, color: "text-iv-cyan" },
           { label: "Total Time", value: `${data.total_minutes} min`, color: "text-iv-text" },
-          { label: "Wasted (80-100%)", value: `${data.wasted_minutes_80_100} min`, color: "text-iv-red" },
-          { label: "Wasted %", value: `${data.wasted_pct}%`, color: "text-iv-yellow" },
+          { label: "Wasted (80-100%)", value: `${wastedMinutes} min`, color: "text-iv-red" },
+          { label: "Wasted %", value: `${wastedPct}%`, color: "text-iv-yellow" },
         ].map((item) => (
           <div key={item.label} className="glass rounded-xl border border-iv-border p-4 text-center">
             <p className="text-xs text-iv-text-muted uppercase tracking-wider">{item.label}</p>
             <p className={`text-xl font-bold mt-1 ${item.color}`}>{item.value}</p>
           </div>
         ))}
+      </div>
+
+      {/* kW vs SoC% Line Chart */}
+      <div className="glass rounded-2xl border border-iv-border p-6">
+        <div className="flex items-center gap-2 mb-4">
+          <BatteryWarning className="h-5 w-5 text-iv-cyan" />
+          <h3 className="text-lg font-bold text-iv-text">Charging Power vs SoC</h3>
+        </div>
+        <div className="h-72 w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={data.curve} margin={{ top: 8, right: 8, left: 8, bottom: 8 }}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-iv-border" />
+              <XAxis dataKey="soc_pct" tick={{ fontSize: 12 }} className="text-iv-muted"
+                label={{ value: "SoC %", position: "insideBottom", offset: -5, style: { fill: "var(--iv-muted)" } }} />
+              <YAxis tick={{ fontSize: 12 }} className="text-iv-muted"
+                label={{ value: "Power (kW)", angle: -90, position: "insideLeft", style: { fill: "var(--iv-muted)" } }} />
+              <Tooltip
+                contentStyle={{ backgroundColor: "var(--iv-bg)", border: "1px solid var(--iv-border)", borderRadius: "8px" }}
+                labelStyle={{ color: "var(--iv-muted)" }}
+                formatter={(value: number, name: string) => [value.toFixed(2), name === "avg_power_kw" ? "Avg Power (kW)" : "Max Power (kW)"]}
+                labelFormatter={(label) => `SoC: ${label}%`}
+              />
+              <Legend wrapperStyle={{ paddingTop: "16px" }} />
+              <Line type="monotone" dataKey="avg_power_kw" stroke="var(--iv-cyan)" strokeWidth={2} dot={false} name="avg_power_kw" />
+              <Line type="monotone" dataKey="max_power_kw" stroke="var(--iv-green)" strokeWidth={2} strokeDasharray="5 5" dot={false} name="max_power_kw" />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+        {/* Wasted time callout */}
+        {wastedMinutes > 0 && (
+          <div className="mt-4 bg-red-500/10 border border-red-500/30 rounded-xl p-4 flex items-center gap-3">
+            <Clock className="h-5 w-5 text-iv-red flex-shrink-0" />
+            <p className="text-sm text-iv-text">
+              <span className="font-bold text-iv-red">{wastedMinutes} minutes wasted on last 20%</span>
+              <span className="text-iv-text-muted ml-2">(≈{wastedPct}% of total charging time)</span>
+            </p>
+          </div>
+        )}
       </div>
 
       {/* Bar chart: energy and time per bracket */}
@@ -124,16 +164,6 @@ export function ChargingCurveIntegralsDashboard({ vehicleId, dateRange }: { vehi
           </ResponsiveContainer>
         </div>
       </div>
-
-      {/* Wasted time warning */}
-      {data.wasted_minutes_80_100 > 0 && (
-        <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-4">
-          <p className="text-sm text-iv-text">
-            <span className="font-bold text-iv-red">Charging 80-100% wastes {data.wasted_minutes_80_100} minutes</span> per session
-            (≈{data.wasted_pct}% of total charging time). Consider stopping at 80% for daily drives.
-          </p>
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/lib/api/statistics.ts
+++ b/frontend/src/lib/api/statistics.ts
@@ -205,8 +205,9 @@ export const statisticsApi = {
     return res.json();
   },
 
-  async getChargingCurveIntegralsV2(id: string, opts?: { fromDate?: string; toDate?: string }) {
+  async getChargingCurveIntegralsV2(id: string, opts?: { sessionId?: string | number; fromDate?: string; toDate?: string }) {
     const params = new URLSearchParams();
+    if (opts?.sessionId != null) params.set("session_id", String(opts.sessionId));
     if (opts?.fromDate) params.set("from_date", opts.fromDate);
     if (opts?.toDate) params.set("to_date", opts.toDate);
     const res = await apiFetch(`/api/v1/vehicles/${id}/analytics/charging-curve-integrals-v2?${params.toString()}`);


### PR DESCRIPTION
### **User description**
## 📋 Summary

Adds charging power curve visualization (kW vs SoC%) with actual timestamps and calculates minutes wasted on the last 20% SoC charge. Closes #1ff4a9a81ff4a9a8.
<!-- 🤖 PR Agent will automatically enhance this description with detailed file walkthrough -->
<!-- ⚠️ This section must be filled out (at least 20 characters) for PR validation to pass -->

**Related Issues:** Closes #1ff4a9a8


---

## 🧩 Type of Change

<!-- Mark the relevant option with an 'x' - At least one must be checked for PR validation -->

- [x] 🆕 New feature (e.g. new dashboard, API endpoint)
- [ ] 🐛 Bug fix
- [ ] ⚙️ Backend change (API, collector, database)
- [ ] 🎨 Frontend change (UI, charts, pages)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

<!-- Mark completed items with an 'x' -->

- [ ] Backend runs and tests pass (if applicable)
- [ ] Frontend builds (`npm run build` in `frontend/`)
- [ ] Manual testing done (if applicable)

---

## 👥 Reviewer Notes

<!-- What should reviewers focus on? Any specific questions or areas of uncertainty? -->


---

## 📌 Additional Context

<!-- Any other context, links to documentation, or important notes -->


___

### **PR Type**
Enhancement, Frontend


___

### **Description**
- Adds a new line chart visualizing charging power (kW) against State of Charge (SoC%).

- Implements actual timestamp-based duration calculation for charging sessions instead of sampling estimates.

- Introduces a `session_id` filter for the charging curve analytics endpoint.

- Enhances the UI with a "wasted time" callout for the 80-100% SoC range.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Backend
    A["analytics.py"] -- "Calculates duration via min/max timestamps" --> B["API Response"]
    C["session_id filter"] -- "Refines query" --> A
  end
  subgraph Frontend
    B -- "Provides curve data" --> D["ChargingCurveIntegralsDashboard"]
    D -- "Renders" --> E["LineChart (kW vs SoC)"]
    D -- "Displays" --> F["Wasted Time Callout"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.py</strong><dd><code>Improve charging analytics precision and filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/api/v1/analytics.py

<ul><li>Added <code>session_id</code> query parameter to <code>get_charging_curve_integrals_v2</code>.<br> <li> Refactored SQL queries to use a shared base filter.<br> <li> Updated duration logic to use <code>min</code> and <code>max</code> timestamps for precise <br>minute calculation.<br> <li> Added timezone handling for timestamp subtraction.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/101/files#diff-1bcd451e46734de2d8e97d41344307998190a3de95c7b5d405ec226041d1cfb3">+45/-20</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>statistics.ts</strong><dd><code>Update API client for session filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/lib/api/statistics.ts

<ul><li>Updated <code>getChargingCurveIntegralsV2</code> method signature to accept an <br>optional <code>sessionId</code>.<br> <li> Appends <code>session_id</code> to the URL search parameters if provided.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/101/files#diff-bc643e5fed3d67fb20df8c0a4d9270323b52b3eea60c79483820650d2282f176">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Frontend</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChargingCurveIntegralsDashboard.tsx</strong><dd><code>Add power curve chart and UI callouts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/statistics/ChargingCurveIntegralsDashboard.tsx

<ul><li>Integrated <code>LineChart</code> from Recharts to display <code>avg_power_kw</code> and <br><code>max_power_kw</code> vs <code>soc_pct</code>.<br> <li> Added a prominent callout component to highlight time wasted charging <br>above 80%.<br> <li> Updated data validation to check for curve data presence.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/101/files#diff-250e8477d25ded1e8f6f499b1a4504d7cc1731e84794b15a484af59055f80174">+47/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with analytics improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Documented the addition of <code>session_id</code> filtering and the switch to <br>timestamp-based duration calculations.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/101/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

