### PR TITLE
fix: _elevation_cache LRU implementation + ChargingCurveDashboard apiFetch

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections import OrderedDict
 from datetime import datetime, date, timedelta
 from uuid import UUID
 from typing import Any
@@ -1017,13 +1018,16 @@ async def get_charging_curve_integrals_v2(
 # =============================================================================
 # TASK 3: Elevation Penalty & Regen Efficiency
 # =============================================================================
-_elevation_cache: dict[str, float] = {}
+_elevation_cache: OrderedDict[str, float] = OrderedDict()
 
 
 async def _get_nearest_elevation(lat: float, lon: float, vehicle_id: UUID, db: AsyncSession) -> float | None:
     """Get elevation from vehicle_positions nearest to given lat/lon."""
     if lat is None or lon is None:
         return None
+    cache_key = f"{lat:.4f},{lon:.4f}"
+    if cache_key in _elevation_cache:
+        return _elevation_cache[cache_key]
     try:
         res = await db.execute(
             text("""
@@ -1040,7 +1044,12 @@ async def _get_nearest_elevation(lat: float, lon: float, vehicle_id: UUID, db: A
             {"vid": str(vehicle_id), "lat": lat, "lon": lon}
         )
         row = res.first()
-        return float(row[0]) if row else None
+        result = float(row[0]) if row else None
+        if result is not None:
+            _elevation_cache[cache_key] = result
+            if len(_elevation_cache) > 500:
+                _elevation_cache.popitem(last=False)
+        return result
     except Exception:
         return None
 

--- a/frontend/src/components/statistics/ChargingCurveDashboard.tsx
+++ b/frontend/src/components/statistics/ChargingCurveDashboard.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback } from "react";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from "recharts";
 import { Loader2, Zap, Clock, BatteryWarning } from "lucide-react";
 import { api } from "@/lib/api";
+import { statisticsApi } from "@/lib/api/statistics";
 
 interface CurvePoint {
   soc_pct: number;
@@ -31,46 +32,22 @@ export function ChargingCurveDashboard({ vehicleId, dateRange }: { vehicleId: st
 
   const fetchData = useCallback(async () => {
     setLoading(true);
-    const controller = new AbortController();
     try {
-      // Assuming api.fetchWrapper can be used or just use native fetch if not defined
-      const token = localStorage.getItem("access_token");
-      let url = `/api/v1/vehicles/${vehicleId}/analytics/charging-curve-integrals`;
-      if (dateRange?.from && dateRange?.to) {
-        url += `?from_date=${dateRange.from.toISOString()}&to_date=${dateRange.to.toISOString()}`;
-      }
-      const res = await fetch(url, {
-        headers: { Authorization: `Bearer ${token}` },
-        signal: controller.signal
+      const json = await statisticsApi.getChargingCurveIntegralsV2(vehicleId, {
+        fromDate: dateRange?.from?.toISOString(),
+        toDate: dateRange?.to?.toISOString(),
       });
-      if (res.ok) {
-        const json = await res.json();
-        setData(json);
-      } else {
-        setData(null);
-      }
+      setData(json);
     } catch (err: any) {
-      if (err.name !== 'AbortError') {
-        setData(null);
-      }
+      setData(null);
     } finally {
       setLoading(false);
     }
-    
-    return controller;
   }, [vehicleId, dateRange?.from?.getTime(), dateRange?.to?.getTime()]);
 
   useEffect(() => {
-    let activeController: AbortController | null = null;
-    fetchData().then(controller => {
-      activeController = controller;
-    });
-    
-    return () => {
-      if (activeController) {
-        activeController.abort();
-      }
-    };
+    fetchData();
+
   }, [fetchData]);
 
   if (loading) {


### PR DESCRIPTION
### **User description**
## Summary

**Finding 1 — MEDIUM / backend** (`analytics.py:1020`)
- `_elevation_cache` was declared but **never read or written** — SQL query on every call
- Fix: Implement the cache with LRU cap at 500 entries using `OrderedDict`

**Finding 2 — HIGH / frontend** (`ChargingCurveDashboard.tsx:37-48`)
- Component bypassed `apiFetch`, used raw `localStorage.getItem("access_token")` + `fetch()`
- Fix: Replace with `statisticsApi.getChargingCurveIntegralsV2()` which already exists

**Source:** m7xlabcoder daily code review (session `28423890`)

## Files Changed
- `backend/app/api/v1/analytics.py` — elevation cache with LRU cap
- `frontend/src/components/statistics/ChargingCurveDashboard.tsx` — use apiFetch

---
*Generated by iVDrive Team ®*


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Implemented LRU caching for elevation data using `OrderedDict` with a 500-entry limit.

- Refactored `ChargingCurveDashboard` to use `statisticsApi` instead of raw `fetch`.

- Removed manual token handling and `AbortController` logic in the frontend.

- Improved backend performance by reducing redundant SQL queries for elevation lookups.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Frontend
  A["ChargingCurveDashboard"] -- "uses" --> B["statisticsApi"]
  end
  subgraph Backend
  C["_get_nearest_elevation"] -- "checks" --> D["_elevation_cache (LRU)"]
  D -- "miss" --> E["PostgreSQL"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.py</strong><dd><code>Implement LRU caching for elevation data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/api/v1/analytics.py

<ul><li>Replaced standard <code>dict</code> with <code>OrderedDict</code> for <code>_elevation_cache</code>.<br> <li> Added cache lookup logic using a coordinate-based key.<br> <li> Implemented LRU eviction policy by popping the oldest item when the <br>cache exceeds 500 entries.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/106/files#diff-1bcd451e46734de2d8e97d41344307998190a3de95c7b5d405ec226041d1cfb3">+11/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ChargingCurveDashboard.tsx</strong><dd><code>Refactor data fetching to use centralized API service</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/statistics/ChargingCurveDashboard.tsx

<ul><li>Replaced manual <code>fetch</code> and <code>localStorage</code> access with <br><code>statisticsApi.getChargingCurveIntegralsV2</code>.<br> <li> Simplified <code>fetchData</code> by removing <code>AbortController</code> and manual URL <br>construction.<br> <li> Cleaned up <code>useEffect</code> to directly invoke the simplified <code>fetchData</code> <br>function.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/106/files#diff-2124ebb4668e70a7562d1fa92cd411de434b7a0c999e8eb05b2cd05a15fc5002">+8/-31</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

