### PR TITLE
Merge elevation cache LRU + response_model fixes into development

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -2005,6 +2005,7 @@ async def get_predictive_soc(
         Trip.distance_km.is_not(None),
         Trip.distance_km > 5,
         Trip.kwh_consumed.is_not(None),
+        Trip.kwh_consumed > 0,
         Trip.avg_temp_celsius.is_not(None)
     ).order_by(Trip.start_date.desc()).limit(100)
     trips_res = await db.execute(trips_stmt)
@@ -2042,6 +2043,7 @@ async def get_predictive_soc(
             "predicted_arrival_soc_pct": round(current_soc, 1),
             "confidence_pct": 30,
             "message": "Not enough trip data for prediction.",
+            "consumption_by_temp": {},
             "consumption_data": []
         }
 
@@ -2081,7 +2083,7 @@ async def get_predictive_soc(
 
     cat_trips = len(cat_effs)
     confidence = min(95, 30 + cat_trips * 5)
-    arrival_soc = max(0.0, min(100.0, arrival_soc))
+    arrival_soc = max(0.0, arrival_soc)  # Clamp floor only; upper bound enforced by caller
 
     return {
         "current_soc_pct": round(current_soc, 1),

--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections import OrderedDict
 from datetime import datetime, date, timedelta, timezone
 from uuid import UUID
 from typing import Any
@@ -1272,16 +1273,20 @@ async def get_charging_curve_integrals_v2(
 # =============================================================================
 # TASK 3: Elevation Penalty & Regen Efficiency
 # =============================================================================
-_elevation_cache: dict[str, float] = {}
+_elevation_cache: OrderedDict[str, float] = OrderedDict()
 
 
 async def _get_nearest_elevation(lat: float, lon: float, vehicle_id: UUID, db: AsyncSession) -> float | None:
     """Get elevation from vehicle_positions nearest to given lat/lon."""
     if lat is None or lon is None:
         return None
+    cache_key = f"{lat:.4f},{lon:.4f}"
+    if cache_key in _elevation_cache:
+        _elevation_cache.move_to_end(cache_key)
+        return _elevation_cache[cache_key]
     try:
         res = await db.execute(
-            text("""
+            text(""""
                 SELECT elevation_m FROM vehicle_positions
                 WHERE user_vehicle_id = :vid
                   AND elevation_m IS NOT NULL
@@ -1295,7 +1300,12 @@ async def _get_nearest_elevation(lat: float, lon: float, vehicle_id: UUID, db: A
             {"vid": str(vehicle_id), "lat": lat, "lon": lon}
         )
         row = res.first()
-        return float(row[0]) if row else None
+        elevation = float(row[0]) if row else None
+        if elevation is not None:
+            _elevation_cache[cache_key] = elevation
+            if len(_elevation_cache) > 500:
+                _elevation_cache.popitem(last=False)
+        return elevation
     except Exception:
         return None
 

--- a/backend/app/api/v1/vehicles.py
+++ b/backend/app/api/v1/vehicles.py
@@ -853,6 +853,9 @@ async def get_trip_elevation_stats(
     net_elevation_m = end_elev - start_elev
 
     return {
+        "trip_id": trip_id,
+        "start_elevation_m": round(start_elev, 1),
+        "end_elevation_m": round(end_elev, 1),
         "elevation_gain_m": round(elevation_gain_m, 1),
         "elevation_loss_m": round(elevation_loss_m, 1),
         "net_elevation_m": round(net_elevation_m, 1),


### PR DESCRIPTION
### **User description**
Merges:
- dd3e3ec: _elevation_cache LRU cap 500 + OrderedDict cache with move_to_end
- cc4d87d: trip elevation response_model, arrival SoC division-by-zero, Speed x Temp panel


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Implements an LRU cache for elevation lookups.

- Fixes division-by-zero in SoC prediction logic.

- Updates trip elevation response with missing fields.

- Adds missing fields to early return responses.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Analytics
    A["_get_nearest_elevation"] -- "Check Cache" --> B["OrderedDict LRU"]
    B -- "Miss" --> C["SQL Query"]
    C -- "Store" --> B
  end
  subgraph Prediction
    D["get_predictive_soc"] -- "Filter" --> E["kwh_consumed > 0"]
  end
  subgraph API
    F["get_trip_elevation_stats"] -- "Add Fields" --> G["trip_id, start/end_elev"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.py</strong><dd><code>Implement elevation LRU cache and fix SoC calculation bugs</code></dd></summary>
<hr>

backend/app/api/v1/analytics.py

<ul><li>Replaced the unused <code>_elevation_cache</code> dict with an <code>OrderedDict</code> to <br>implement a proper LRU cache with a 500-entry limit.<br> <li> Added a <code>kwh_consumed > 0</code> filter to the trip selection in <br><code>get_predictive_soc</code> to prevent division-by-zero errors.<br> <li> Added <code>consumption_by_temp</code> to the early return dictionary when no trips <br>are found.<br> <li> Modified <code>arrival_soc</code> clamping to only enforce a floor of 0.0.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/117/files#diff-1bcd451e46734de2d8e97d41344307998190a3de95c7b5d405ec226041d1cfb3">+16/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vehicles.py</strong><dd><code>Update trip elevation response model fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/api/v1/vehicles.py

<ul><li>Updated the return dictionary of <code>get_trip_elevation_stats</code> to include <br><code>trip_id</code>, <code>start_elevation_m</code>, and <code>end_elevation_m</code>.<br> <li> Ensures the response matches the expected <code>TripElevationStats</code> schema.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/117/files#diff-e0ad806f7f5d6a9fafbabd69de3ca022741428c9494b44af10a084474d3a2f8d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

