### PR TITLE
fix(alembic): merge vehicle_positions index branches — resolve multiple heads

### DIFF
--- a/backend/app/migrations/versions/585b1cc2eb03_merge_vehicle_positions_elevation_into_production.py
+++ b/backend/app/migrations/versions/585b1cc2eb03_merge_vehicle_positions_elevation_into_production.py
@@ -1,0 +1,29 @@
+"""merge vehicle_positions composite index branch back to main (battery SoH) line
+
+Revision ID: 585b1cc2eb03
+Revises: d1e2f3a4bb5c, f36d25e55dd8
+Create Date: 2026-05-04 22:05:00.000000
+
+Merge of:
+- d1e2f3a4bb5c: add index on vehicle_positions for elevation lookups
+              (down_revision: a1b2c3d4e5f8 -> composite index branch)
+- f36d25e55dd8: add_battery_soh_estimates_table_v2 (main line)
+
+Branch tree resolution: The vehicle_positions index migrations were merged
+back into the main line at the same revision as battery SoH v2.
+"""
+
+
+# revision identifiers, used by Alembic.
+revision: str = '585b1cc2eb03'
+down_revision: tuple = ('d1e2f3a4bb5c', 'f36d25e55dd8')
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/migrations/versions/d1e2f3a4bb5c_add_index_vp_vehicle_elevation.py
+++ b/backend/app/migrations/versions/d1e2f3a4bb5c_add_index_vp_vehicle_elevation.py
@@ -9,7 +9,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = 'd1e2f3a4bb5c'
-down_revision: str = 'f493b86626a'
+down_revision: str = 'a1b2c3d4e5f8'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
### **User description**
## 📋 Summary

Emergency fix: resolve alembic "multiple heads" error that blocked v1.0.23 production deployment. The production DB was already at the correct revision (f36d25e55dd8, battery SoH v2), but two unmerged elevation index migrations created phantom heads that blocked `alembic upgrade head`.

## 🧩 Type of Change

- [ ] 🆕 New feature
- [x] 🐛 Bug fix
- [ ] ⚙️ Backend change (API, collector, database)
- [ ] 🎨 Frontend change (UI, charts, pages)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

## ✅ Validation

- [x] alembic heads → single head (585b1cc2eb03)
- [x] alembic upgrade head → succeeds (no-op, already at head)
- [ ] Backend runs and tests pass (if applicable)
- [ ] Manual testing done (if applicable)

## 👥 Reviewer Notes

**Root cause:**  
Two migration branches both tried to create the same index `ix_vp_vehicle_positions_elevation_lat_lon` on the same columns from the same parent `f493b86626a`:
- `a1b2c3d4e5f8` (composite index, created 2026-04-30 20:45)
- `d1e2f3a4bb5c` (single index, created 2026-04-30 16:50)

These were never merged back into the main battery SoH line (`f36d25e55dd8`), creating 3 heads.

**Fix applied in production (already stamped at 585b1cc2eb03):**
1. Reparented `d1e2f3a4bb5c` → `down_revision: 'a1b2c3d4e5f8'` (runs after composite, no conflict)
2. Created merge revision `585b1cc2eb03` with `down_revision: ('d1e2f3a4bb5c', 'f36d25e55dd8')`

**Production DB is healthy** — stamped at merge revision 585b1cc2eb03. Elevation index was never applied to the DB (no performance impact, same as before this migration series).

Merge ASAP — needed for next production deployment to avoid the same block.


___

### **PR Type**
Bug fix


___

### **Description**
- Resolves Alembic "multiple heads" error by merging divergent migration branches.

- Reparents elevation index migration to follow the composite index revision.

- Introduces a new merge revision to unify the database schema history.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["f493b86626a (Parent)"]
  B["a1b2c3d4e5f8 (Composite Index)"]
  C["d1e2f3a4bb5c (Elevation Index)"]
  D["f36d25e55dd8 (Battery SoH v2)"]
  E["585b1cc2eb03 (Merge Head)"]

  A -- "original parent" --> B
  B -- "new parent (reparented)" --> C
  C -- "merge" --> E
  D -- "merge" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>585b1cc2eb03_merge_vehicle_positions_elevation_into_production.py</strong><dd><code>Create merge revision to unify migration heads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/migrations/versions/585b1cc2eb03_merge_vehicle_positions_elevation_into_production.py

<ul><li>Created a new Alembic merge revision <code>585b1cc2eb03</code>.<br> <li> Combines the elevation index branch (<code>d1e2f3a4bb5c</code>) and the battery SoH <br>branch (<code>f36d25e55dd8</code>) into a single head.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/124/files#diff-bbec7e8eae97cb330d2c8ad5e0eedd77adb640db01d90a90e8318f3b08b3a687">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>d1e2f3a4bb5c_add_index_vp_vehicle_elevation.py</strong><dd><code>Reparent elevation index migration to resolve branching</code>&nbsp; &nbsp; </dd></summary>
<hr>

backend/app/migrations/versions/d1e2f3a4bb5c_add_index_vp_vehicle_elevation.py

<ul><li>Updated <code>down_revision</code> from <code>f493b86626a</code> to <code>a1b2c3d4e5f8</code>.<br> <li> This change linearizes the two migrations that were previously <br>creating conflicting indices from the same parent.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/124/files#diff-b4720b55431c8a46924a64f616ac57785806bfd790c129aa9f0af892fb9e0350">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

