### PR TITLE
fix(security-scan): add Trivy DB download, exit-code 0, remove broken SEMGREP_APP_TOKEN

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -54,9 +54,10 @@ jobs:
           format: 'sarif'
           output: 'trivy-image.sarif'
           severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true        # don't fail on CVEs that have no fix yet
-          exit-code: '0'              # report only, do not block on base image CVEs
+          ignore-unfixed: true
+          exit-code: '0'              # report only, don't fail build
           vuln-type: 'os,library'
+          cache-dir: .trivy-cache
 
       - name: Upload Trivy image SARIF
         if: always()
@@ -86,6 +87,7 @@ jobs:
           ignore-unfixed: true
           # Scan deps, IaC, and secrets in one pass
           scanners: 'vuln,misconfig,secret'
+          exit-code: '0'
 
       - name: Upload Trivy fs SARIF
         if: always()
@@ -111,10 +113,8 @@ jobs:
             --config=p/default \
             --config=p/security-audit \
             --config=p/secrets \
+            --disable-version-check \
             --sarif --output=semgrep.sarif
-        env:
-          # Optional: set SEMGREP_APP_TOKEN as a secret for the managed dashboard
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 
       - name: Upload Semgrep SARIF
         if: always()


### PR DESCRIPTION
### **User description**
## 📋 Summary

<!-- Brief description of what this PR does and why -->
<!-- 🤖 PR Agent will automatically enhance this description with detailed file walkthrough -->
<!-- ⚠️ This section must be filled out (at least 20 characters) for PR validation to pass -->

**Related Issues:** Closes #


---

## 🧩 Type of Change

<!-- Mark the relevant option with an 'x' - At least one must be checked for PR validation -->

- [ ] 🆕 New feature (e.g. new dashboard, API endpoint)
- [ ] 🐛 Bug fix
- [ ] ⚙️ Backend change (API, collector, database)
- [ ] 🎨 Frontend change (UI, charts, pages)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

<!-- Mark completed items with an 'x' -->

- [ ] Backend runs and tests pass (if applicable)
- [ ] Frontend builds (`npm run build` in `frontend/`)
- [ ] Manual testing done (if applicable)

---

## 👥 Reviewer Notes

<!-- What should reviewers focus on? Any specific questions or areas of uncertainty? -->


---

## 📌 Additional Context

<!-- Any other context, links to documentation, or important notes -->


---

Sync main with development security-scan fixes:

- Add explicit Trivy DB download step (fixes db not initialized failures)
- exit-code 0 on all Trivy jobs (report-only, doesn't block merges)
- Remove broken SEMGREP_APP_TOKEN (not needed for free CI scanning)
- Add --disable-version-check to Semgrep


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added explicit Trivy DB download step.

- Configured Trivy to use local cache directory.

- Set exit-code to 0 for all scans.

- Removed SEMGREP_APP_TOKEN and added version check disable.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph "Security Workflow"
    direction TB
    TDB["Download Trivy DB"] -- "Cache" --> TImg["Trivy Image Scan"]
    TImg -- "Exit Code 0" --> US["Upload SARIF"]
    Sem["Semgrep Scan"] -- "Disable Version Check" --> US
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security-scan.yml</strong><dd><code>Update security scanning steps and configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/security-scan.yml

<ul><li>Added a dedicated step to download the Trivy vulnerability database <br>with caching enabled.<br> <li> Updated the Trivy image scan to use the local cache and ensured it <br>returns an exit code of 0.<br> <li> Added <code>exit-code: '0'</code> to the Trivy filesystem scan to prevent workflow <br>failures.<br> <li> Removed <code>SEMGREP_APP_TOKEN</code> and added <code>--disable-version-check</code> to the <br>Semgrep command.<br> <li> Commented out the <code>GITLEAKS_LICENSE</code> environment variable.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/126/files#diff-1adb34cd46df4e96bfa50d4b5ebf5c4f1bfcbaa514a44e9151f75efb6033d937">+13/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

