### PR TITLE
fix(security-scan): update Trivy action to v0.49.1, remove separate DB download step

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -43,20 +43,28 @@ jobs:
           file: ./backend/Dockerfile
           target: api
           load: true
-          tags: app:scan
+          tags: app:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.49.1
+      - name: Download Trivy vulnerability database
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: 'app:scan'
+          version: '0.36.0'
+          update-cache: true
+          cache-dir: .trivy-cache
+
+      - name: Run Trivy on the image (SARIF)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: 'app:${{ github.sha }}'
           format: 'sarif'
           output: 'trivy-image.sarif'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
-          exit-code: '0'              # report only, don't fail build
+          exit-code: '1'
           vuln-type: 'os,library'
+          cache-dir: .trivy-cache
 
       - name: Upload Trivy image SARIF
         if: always()
@@ -64,6 +72,18 @@ jobs:
         with:
           sarif_file: 'trivy-image.sarif'
           category: trivy-image
+
+      - name: Trivy image scan (table, logs)
+        if: always()
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: 'app:${{ github.sha }}'
+          format: 'table'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          exit-code: '0'
+          vuln-type: 'os,library'
+          cache-dir: .trivy-cache
 
   # ─────────────────────────────────────────────
   # 2. Filesystem + IaC scan (Trivy fs)
@@ -76,7 +96,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@0.49.1
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: './backend'
@@ -86,7 +106,7 @@ jobs:
           ignore-unfixed: true
           # Scan deps, IaC, and secrets in one pass
           scanners: 'vuln,misconfig,secret'
-          exit-code: '0'
+          exit-code: '1'
 
       - name: Upload Trivy fs SARIF
         if: always()

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -47,15 +47,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Download Trivy vulnerability database
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          version: '0.36.0'
-          update-cache: true
-          cache-dir: .trivy-cache
-
-      - name: Run Trivy on the image
-        uses: aquasecurity/trivy-action@v0.36.0
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.49.1
         with:
           image-ref: 'app:scan'
           format: 'sarif'
@@ -64,7 +57,6 @@ jobs:
           ignore-unfixed: true
           exit-code: '0'              # report only, don't fail build
           vuln-type: 'os,library'
-          cache-dir: .trivy-cache
 
       - name: Upload Trivy image SARIF
         if: always()
@@ -84,7 +76,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@0.49.1
         with:
           scan-type: 'fs'
           scan-ref: './backend'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## [Unreleased] - 2026-05-04
+## [Unreleased] - 2026-05-05
 ### Added
 - BatterySoHDashboard: Battery SoH tab with derived SoH from charging sessions + Skoda BMS comparison + degradation curve (via `battery-health` endpoint).
 
 ### Fixed
+- security-scan.yml: Update Trivy action from v0.36.0 to v0.49.1, remove separate DB download step (v0.49.1 handles DB init automatically). Fixes "Download Trivy vulnerability database" step failure blocking all workflow runs.
 - ChargingEconomicsDashboard: Remove duplicate Recent Sessions Table block (copy-paste error — same table rendered twice).
 - CarOverviewDashboard: Switch `Promise.all` → `Promise.allSettled` — if 1-2 of 15 parallel API requests fail, dashboard still renders partial data.
 - StatisticsShell: Guard ArrowLeft/ArrowRight keyboard navigation against `input`/`textarea` elements (accessibility).


### PR DESCRIPTION
### **User description**
## 📋 Summary

<!-- Brief description of what this PR does and why -->
<!-- ⚠️ This section must be filled out (at least 20 characters) for PR validation to pass -->

Update Trivy GitHub Action from v0.36.0 to v0.49.1. Remove the separate DB download step — v0.49.1 handles DB init automatically. Fixes the \"Download Trivy vulnerability database\" step failure.

**Related Issues:** Closes #


---

## 🧩 Type of Change

<!-- Mark the relevant option with an x -->
- [ ] 🆕 New feature
- [x] 🐛 Bug fix
- [ ] ⚙️ Backend change
- [ ] 🎨 Frontend change
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

- [ ] Backend runs and tests pass
- [ ] Frontend builds
- [ ] Manual testing done

---

## 👥 Reviewer Notes

<!-- What should reviewers focus on? -->


---

## 📌 Additional Context

<!-- Any other context, links, notes -->


---


___

### **PR Type**
Bug fix, Other


___

### **Description**
- Update `aquasecurity/trivy-action` from v0.36.0 to 0.49.1.

- Remove redundant vulnerability database download step.

- Simplify scanner configuration by removing `cache-dir`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Old_Workflow ["Old Workflow"]
    A["Download DB"] --> B["Run Scan"]
  end
  subgraph New_Workflow ["New Workflow"]
    C["Run Scan (Auto DB)"]
  end
  Old_Workflow -- "Update & Simplify" --> New_Workflow
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>security-scan.yml</strong><dd><code>Update Trivy action version and remove redundant steps</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/security-scan.yml

<ul><li>Updated <code>aquasecurity/trivy-action</code> version to 0.49.1 across all jobs.<br> <li> Deleted the explicit "Download Trivy vulnerability database" step as <br>it is now handled automatically.<br> <li> Removed the <code>cache-dir</code> parameter from the image scan configuration.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/127/files#diff-1adb34cd46df4e96bfa50d4b5ebf5c4f1bfcbaa514a44e9151f75efb6033d937">+3/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

