### PR TITLE
fix(HVACCostCard): ensure numeric type for toFixed() — prevent 510°C string concat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## [Unreleased] - 2026-05-05
-### Added
+### Fixed
+- HVACCostCard: Wrap `representative_temp_celsius` with `Number()` before `toFixed()` — defensive fix against string concatenation (e.g. "5"+"10"="510°C") if backend returns unexpected type.
 - BatterySoHDashboard: Battery SoH tab with derived SoH from charging sessions + Skoda BMS comparison + degradation curve (via `battery-health` endpoint).
 
 ### Fixed

--- a/frontend/src/components/statistics/HVACCostCard.tsx
+++ b/frontend/src/components/statistics/HVACCostCard.tsx
@@ -64,7 +64,7 @@ function HVACCostCardInner({ vehicleId }: { vehicleId: string }) {
   }
 
   const cost = topMetric.hvac_cost_kwh_100km;
-  const temp = topMetric.representative_temp_celsius;
+  const temp = Number(topMetric.representative_temp_celsius);
 
   return (
     <div className="glass p-5 rounded-2xl border border-iv-border relative overflow-hidden group">


### PR DESCRIPTION
### **User description**
## 📋 Summary

<!-- Brief description of what this PR does and why -->
<!-- 🤖 PR Agent will automatically enhance this description with detailed file walkthrough -->
<!-- ⚠️ This section must be filled out (at least 20 characters) for PR validation to pass -->

**Related Issues:** Closes #


---

## 🧩 Type of Change

<!-- Mark the relevant option with an 'x' - At least one must be checked for PR validation -->

- [ ] 🆕 New feature (e.g. new dashboard, API endpoint)
- [ ] 🐛 Bug fix
- [ ] ⚙️ Backend change (API, collector, database)
- [ ] 🎨 Frontend change (UI, charts, pages)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

<!-- Mark completed items with an 'x' -->

- [ ] Backend runs and tests pass (if applicable)
- [ ] Frontend builds (`npm run build` in `frontend/`)
- [ ] Manual testing done (if applicable)

---

## 👥 Reviewer Notes

<!-- What should reviewers focus on? Any specific questions or areas of uncertainty? -->


---

## 📌 Additional Context

<!-- Any other context, links to documentation, or important notes -->


---

Defensive fix: wrap representative_temp_celsius with Number() before toFixed() in HVACCostCard. The backend returns temperature as a number for most bands, but defensive coding ensures toFixed() never receives a string (which would produce '510' = '5' + '10' instead of numeric 5+10=15).


___

### **PR Type**
Bug fix


___

### **Description**
- Ensures `representative_temp_celsius` is cast to a `Number`.

- Prevents string concatenation bugs in temperature display.

- Adds a defensive fix for HVAC cost calculations.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Frontend
    HVACCostCard["HVACCostCard.tsx"] -- "Cast to Number" --> Display["Correct Temperature Display"]
  end
  Data["Backend Data"] -- "representative_temp_celsius" --> HVACCostCard
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HVACCostCard.tsx</strong><dd><code>Cast representative temperature to Number for safe formatting</code></dd></summary>
<hr>

frontend/src/components/statistics/HVACCostCard.tsx

<ul><li>Wrapped <code>topMetric.representative_temp_celsius</code> with the <code>Number()</code> <br>constructor.<br> <li> This ensures that subsequent numeric operations or formatting (like <br><code>toFixed</code>) do not result in string concatenation if the API returns a <br>string.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/129/files#diff-efba3351700f82b636e2a5e3c8e3ff65f7782793113e2cc92d305fb65b3a3485">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with HVAC cost card fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added a new entry under the Fixed section for the HVACCostCard <br>temperature display fix.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/129/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

