### PR TITLE
Fix: statistics gap-fill key mismatch between ISO and space-separated period formats

### DIFF
--- a/backend/app/api/v1/vehicles.py
+++ b/backend/app/api/v1/vehicles.py
@@ -1390,6 +1390,51 @@ async def get_statistics(
             )
         )
 
+    # Gap-fill: ensure every period in the requested window has an entry (zero-fill missing periods)
+    if from_date and to_date and limit > 0:
+        tz = _tz_for_vehicle(vehicle)
+        trunc = trunc_map[period]
+        # Normalize: main query produces ISO ("T"), gap-fill produces space-separated.
+        # Convert both to ISO T format so the map lookup works.
+        results_map = {r.period.replace(" ", "T").split("+")[0]: r for r in results}
+        filled = []
+        try:
+            # Subtract 1 day from to_date so generate_series is inclusive of last day.
+            to_date_bound = to_date - timedelta(days=1)
+            gen_sql = text(
+                f"SELECT period::text "
+                f"FROM generate_series("
+                f"  date_trunc('{trunc}', :from_dt AT TIME ZONE :tz), "
+                f"  date_trunc('{trunc}', :to_dt AT TIME ZONE :tz) - INTERVAL '1 {trunc}', "
+                f"  INTERVAL '1 {trunc}' "
+                f") AS period ORDER BY period DESC LIMIT :lim"
+            )
+            gen_res = await db.execute(gen_sql, {"from_dt": from_date, "to_dt": to_date_bound, "lim": limit, "tz": tz})
+            all_gen = [row[0] for row in gen_res.fetchall()]
+        except Exception:
+            all_gen = []
+        for period_str in all_gen:
+            # Gap-fill returns 'YYYY-MM-DD HH:MM:SS' with space; normalize to ISO T
+            period_key = period_str.replace(" ", "T").split("+")[0]
+            if period_key in results_map:
+                filled.append(results_map[period_key])
+            else:
+                filled.append(
+                    StatisticsPeriod(
+                        period=period_key,
+                        drives_count=0,
+                        total_distance_km=0.0,
+                        time_driven_seconds=0.0,
+                        median_distance_km=None,
+                        charging_sessions_count=0,
+                        total_energy_kwh=0.0,
+                        total_kwh_consumed=0.0,
+                        avg_energy_per_session_kwh=0.0,
+                        time_charging_seconds=0.0,
+                    )
+                )
+        results = filled
+
     _log_statistics_query(
         "statistics", vehicle_id, from_date=from_date, to_date=to_date, limit=limit, result_count=len(results), extra={"period": period}, sql=" | ".join(filter(None, [_stmt_to_sql(stmt_trip), _stmt_to_sql(stmt_charge)])) or None
     )


### PR DESCRIPTION
### **User description**
## Summary

Fix Bug #1: Statistics API gap-fill was returning empty arrays when from_date and to_date were both provided.

**Root Cause:** Period key format mismatch — main query produces ISO "T" format keys (e.g. ) while gap-fill generates "space-separated" format (e.g. ). Map lookup always failed, zero-filling all periods.

**Fix:** Normalize both sides to ISO T format before map lookup. Also subtract 1 day from to_date bound for inclusive date range.

## Testing
- API returns 8 rows (May 1-8) with correct zero-fill for non-driving days
- Verified via browser: Driving Stats shows "NO DATA DAY" labels; Movement tab shows correct date range

---
*Generated by iVDrive Team ®*


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes empty statistics arrays by normalizing date keys.

- Aligns ISO "T" and space-separated date formats.

- Implements gap-filling for missing periods in statistics.

- Adjusts date bounds for inclusive range generation.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph DataNormalization ["Data Normalization"]
    DB["Database Results"] -- "replace ' ' with 'T'" --> Map["Normalized Map"]
    Gen["generate_series"] -- "replace ' ' with 'T'" --> Key["Normalized Key"]
  end
  Map -- "Lookup" --> Key
  Key -- "Match" --> Result["Return Data"]
  Key -- "No Match" --> Zero["Zero-fill Entry"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vehicles.py</strong><dd><code>Fix statistics gap-filling and date normalization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/api/v1/vehicles.py

<ul><li>Implemented a gap-filling mechanism to ensure every period in a <br>requested window has an entry.<br> <li> Added normalization logic to convert space-separated date strings to <br>ISO "T" format for consistent map lookups.<br> <li> Adjusted the <code>to_date</code> bound in the SQL <code>generate_series</code> to ensure the <br>date range is inclusive.<br> <li> Added error handling around the series generation to prevent API <br>crashes on SQL failures.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/135/files#diff-e0ad806f7f5d6a9fafbabd69de3ca022741428c9494b44af10a084474d3a2f8d">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

