### PR TITLE
Fix: DrivingDashboard date filtering + period KPIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [Unreleased] - 2026-05-08
+## [Unreleased] - 2026-05-10
+### Fixed
+- DrivingDashboard + MovementDashboard (frontend): All data sources now respect the selected dateRange — odometer, visited locations, time budget, and trips all use the same period filter. Previously time budget and mileage showed all-time data regardless of the date picker.
+- DrivingDashboard (frontend): KPI cards now show period totals (sum of all days in range) instead of only the latest-day values. Historical stats table now shows all available rows with scrollable overflow instead of hard-coded slice of 7.
+- analytics.py (`movement-stats`): Made `from_date`/`to_date` query params optional — when absent, returns all-time aggregation. Previously called `/time-budget` endpoint which had no date filter support.
+- MovementDashboard (frontend): Time Budget now fetches period-filtered data instead of all-time. Badge updated from "All-time" to "Period".
+
 ### Fixed
 - vehicles.py (`/statistics` endpoint): Timezone-aware day truncation using vehicle.home_tz field — supports all IANA timezones; falls back to Europe/Vilnius for vehicles without home_tz set. Eliminates UTC midnight misalignment that caused Driving Stats historical data to show only 2 days instead of the full selected period. **Security**: Uses SQLAlchemy `.op("AT TIME ZONE")(tz)` instead of `text(f"... '{tz}' ...")` — tz validated against IANA whitelist before reaching SQL.
 - MovementDashboard (frontend): Use geofenceId instead of label string-matching to group Top Places — same Work geofence visits now merge into a single entry regardless of cluster centroid drift. Duration-weighted centroid averaging applied for coordinate-keyed (non-geofence) stays; geofence stays keep original center coordinates.

--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -521,13 +521,22 @@ async def get_legacy_climatization(
 @router.get("/{vehicle_id}/analytics/movement-stats")
 async def get_movement_stats(
     vehicle_id: UUID,
-    from_date: datetime = Query(...),
-    to_date: datetime = Query(...),
+    from_date: datetime | None = Query(default=None),
+    to_date: datetime | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
     """Returns accurate time-budget breakdown using real vehicle_states and charging_states."""
     await get_user_vehicle(user.id, vehicle_id, db)
+
+    # All-time fallback: if no date range given, use earliest → now
+    if from_date is None or to_date is None:
+        min_date = (datetime.now(timezone.utc) - timedelta(days=365 * 5)).replace(tzinfo=timezone.utc)
+        max_date = datetime.now(timezone.utc)
+        if from_date is None:
+            from_date = min_date
+        if to_date is None:
+            to_date = max_date
 
     # Ensure from_date/to_date are timezone-aware (UTC) so comparisons with
     # timezone-aware DB columns (vehicle_states, charging_states) don't fail

--- a/frontend/src/components/statistics/DrivingDashboard.tsx
+++ b/frontend/src/components/statistics/DrivingDashboard.tsx
@@ -257,11 +257,11 @@ export function DrivingDashboard({ vehicleId, dateRange }: DrivingDashboardProps
       ] = await Promise.allSettled([
         api.getTripsAnalytics(vehicleId, 200, fromISO, toISO),
         api.getStatistics(vehicleId, "day", 30, fromISO, toISO),
-        // ── odometer: no date filter ── full history for mileage trend
-        api.getOdometer(vehicleId, 5000),
-        api.getTimeBudget(vehicleId),
-        // ── visited locations: no date filter ── all-time for map
-        api.getVisitedLocations(vehicleId, 5000),
+        // ── odometer: filtered by dateRange ── period mileage trend
+        api.getOdometer(vehicleId, 5000, fromISO, toISO),
+        api.getTimeBudget(vehicleId, fromISO, toISO),
+        // ── visited locations: filtered by dateRange ── period map
+        api.getVisitedLocations(vehicleId, 5000, fromISO, toISO),
         settingsApi.getGeofences().catch(() => [] as Geofence[]),
       ]);
 
@@ -292,21 +292,33 @@ export function DrivingDashboard({ vehicleId, dateRange }: DrivingDashboardProps
 
   // ── Derived ─────────────────────────────────────────────────────────────────
 
-  // Latest stats row (most recent day)
-  const latestStats = stats.length > 0 ? stats[0] : null;
+  //   // Period totals (sum of all stats rows in date range)
+  const periodTotals = useMemo(() => {
+    if (stats.length === 0) return null;
+    return stats.reduce(
+      (acc, s) => ({
+        total_distance_km: acc.total_distance_km + s.total_distance_km,
+        drives_count: acc.drives_count + s.drives_count,
+        total_kwh_consumed: acc.total_kwh_consumed + s.total_kwh_consumed,
+        total_energy_kwh: acc.total_energy_kwh + s.total_energy_kwh,
+        charging_sessions_count: acc.charging_sessions_count + s.charging_sessions_count,
+      }),
+      { total_distance_km: 0, drives_count: 0, total_kwh_consumed: 0, total_energy_kwh: 0, charging_sessions_count: 0 }
+    );
+  }, [stats]);
 
-  // Historical stats (last 7 days, skip today)
-  const historicalStats = stats.length > 1 ? stats.slice(1, 8) : [];
-
-  // KPI values
-  const totalDistance = latestStats ? latestStats.total_distance_km.toFixed(1) : "—";
-  const totalDrives = latestStats ? String(latestStats.drives_count) : "—";
-  const energyUsed = latestStats ? latestStats.total_kwh_consumed.toFixed(1) : "—";
-  const efficiency = (latestStats && latestStats.total_distance_km > 0 && latestStats.total_kwh_consumed > 0)
-    ? ((latestStats.total_kwh_consumed / latestStats.total_distance_km) * 100).toFixed(1)
+  // KPI values — period totals, not just latest day
+  const totalDistance = periodTotals ? periodTotals.total_distance_km.toFixed(1) : "—";
+  const totalDrives = periodTotals ? String(periodTotals.drives_count) : "—";
+  const energyUsed = periodTotals ? periodTotals.total_kwh_consumed.toFixed(1) : "—";
+  const efficiency = (periodTotals && periodTotals.total_distance_km > 0 && periodTotals.total_kwh_consumed > 0)
+    ? ((periodTotals.total_kwh_consumed / periodTotals.total_distance_km) * 100).toFixed(1)
     : "—";
+  const totalCharged = periodTotals ? periodTotals.total_energy_kwh.toFixed(1) : "—";
+  const totalSessions = periodTotals ? String(periodTotals.charging_sessions_count) : "—";
 
-  // Mileage trend chart data (last 60 odometer readings, reversed → chronological)
+
+Mileage trend chart data (last 60 odometer readings, reversed → chronological)
   // Uses timestamp ms as x-axis value so Recharts can compute proper domain/spacing
   // regardless of how many unique date labels exist
   const mileageChartData = useMemo(() => {
@@ -372,7 +384,7 @@ export function DrivingDashboard({ vehicleId, dateRange }: DrivingDashboardProps
     );
   }
 
-  const hasData = latestStats || odometer.length > 0 || trips.length > 0;
+  const hasData = periodTotals || odometer.length > 0 || trips.length > 0;
 
   if (!hasData) {
     return (
@@ -393,7 +405,7 @@ export function DrivingDashboard({ vehicleId, dateRange }: DrivingDashboardProps
             <span className="text-[10px] font-semibold text-iv-muted uppercase tracking-wide">Distance</span>
           </div>
           <p className="text-2xl font-bold text-iv-text">{totalDistance} <span className="text-sm font-normal text-iv-muted">km</span></p>
-          {latestStats && <p className="text-xs text-iv-muted">{latestStats.drives_count} drives</p>}
+          {periodTotals && <p className="text-xs text-iv-muted">{totalDrives} drives</p>}
         </div>
 
         <div className="glass rounded-xl p-4 space-y-1">
@@ -410,9 +422,9 @@ export function DrivingDashboard({ vehicleId, dateRange }: DrivingDashboardProps
             <span className="text-[10px] font-semibold text-iv-muted uppercase tracking-wide">Charged</span>
           </div>
           <p className="text-2xl font-bold text-iv-text">
-            {latestStats ? latestStats.total_energy_kwh.toFixed(1) : "—"} <span className="text-sm font-normal text-iv-muted">kWh</span>
+            {totalCharged} <span className="text-sm font-normal text-iv-muted">kWh</span>
           </p>
-          {latestStats && <p className="text-xs text-iv-muted">{latestStats.charging_sessions_count} sessions</p>}
+          {periodTotals && <p className="text-xs text-iv-muted">{totalSessions} sessions</p>}
         </div>
 
         <div className="glass rounded-xl p-4 space-y-1">
@@ -429,7 +441,7 @@ export function DrivingDashboard({ vehicleId, dateRange }: DrivingDashboardProps
         <div className="glass rounded-xl p-5 space-y-3">
           <div className="flex items-center justify-between">
             <h3 className="text-sm font-semibold text-iv-text">Mileage Trend</h3>
-            <span className="text-xs bg-iv-surface border border-iv-border text-iv-muted px-2 py-0.5 rounded-full">Last 60 readings</span>
+            <span className="text-xs bg-iv-surface border border-iv-border text-iv-muted px-2 py-0.5 rounded-full">Period readings</span>
           </div>
           <ResponsiveContainer width="100%" height={220}>
             <LineChart data={mileageChartData} margin={{ top: 8, right: 8, left: 8, bottom: 8 }}>
@@ -633,13 +645,13 @@ export function DrivingDashboard({ vehicleId, dateRange }: DrivingDashboardProps
       </div>
 
       {/* ── Historical Stats ── */}
-      {historicalStats.length > 0 && (
+      {stats.length > 0 && (
         <div className="glass rounded-xl p-5 space-y-3">
           <h3 className="text-sm font-semibold text-iv-text flex items-center gap-2">
             <Calendar size={14} /> Historical Driving Data
           </h3>
-          <div className="space-y-1.5">
-            {historicalStats.map((row) => (
+          <div className="space-y-1.5 max-h-64 overflow-y-auto">
+            {stats.map((row) => (
               <div key={row.period} className="flex items-center gap-3 px-3 py-2.5 rounded-lg bg-iv-surface/30 border border-iv-border/20">
                 <div className="p-1.5 rounded-full bg-iv-cyan/10 shrink-0">
                   <Clock size={12} className="text-iv-cyan" />

--- a/frontend/src/components/statistics/MovementDashboard.tsx
+++ b/frontend/src/components/statistics/MovementDashboard.tsx
@@ -172,13 +172,13 @@ export function MovementDashboard({ vehicleId, dateRange }: MovementDashboardPro
   const fromISO = dateRange.from.toISOString();
   const toISO = dateRange.to.toISOString();
 
-  // All-time time budget — fetched once, not date-dependent
+  // Period-based time budget — refetches when date range changes
   useEffect(() => {
     setLoadingBudget(true);
-    api.getTimeBudget(vehicleId)
+    api.getTimeBudget(vehicleId, fromISO, toISO)
       .then(setTimeBudget)
       .finally(() => setLoadingBudget(false));
-  }, [vehicleId]);
+  }, [vehicleId, fromISO, toISO]);
 
   // Period-based location data — refetches when date range changes
   const fetchPeriodData = useCallback(async () => {
@@ -245,11 +245,11 @@ export function MovementDashboard({ vehicleId, dateRange }: MovementDashboardPro
   return (
     <div className="space-y-6">
 
-      {/* ── All-time Time Budget ── */}
+      {/* ── Period Time Budget ── */}
       <div className="glass rounded-xl p-5 space-y-4">
         <div className="flex items-center justify-between">
           <h3 className="text-sm font-semibold text-iv-text">Time Budget</h3>
-          <span className="text-xs bg-iv-surface border border-iv-border text-iv-muted px-2 py-0.5 rounded-full">All-time</span>
+          <span className="text-xs bg-iv-surface border border-iv-border text-iv-muted px-2 py-0.5 rounded-full">Period</span>
         </div>
 
         {loadingBudget ? (

--- a/frontend/src/lib/api/statistics.ts
+++ b/frontend/src/lib/api/statistics.ts
@@ -174,8 +174,13 @@ export const statisticsApi = {
     return res.json();
   },
 
-  async getTimeBudget(id: string): Promise<{ parked_seconds: number; driving_seconds: number; charging_seconds: number; ignition_seconds: number; offline_seconds: number }> {
-    const res = await apiFetch(`/api/v1/vehicles/${id}/analytics/time-budget`);return res.json();
+  async getTimeBudget(id: string, fromDate?: string, toDate?: string): Promise<{ parked_seconds: number; driving_seconds: number; charging_seconds: number; ignition_seconds: number; offline_seconds: number; total_seconds: number }> {
+    const params = new URLSearchParams();
+    if (fromDate) params.set("from_date", fromDate);
+    if (toDate) params.set("to_date", toDate);
+    const qs = params.toString();
+    const url = qs ? `/api/v1/vehicles/${id}/analytics/movement-stats?${qs}` : `/api/v1/vehicles/${id}/analytics/movement-stats`;
+    const res = await apiFetch(url);return res.json();
   },
 
   async getMovementStats(id: string, fromDate: string, toDate: string): Promise<{ parked_seconds: number; driving_seconds: number; charging_seconds: number; offline_seconds: number; ignition_seconds: number; total_seconds: number }> {


### PR DESCRIPTION
## Summary
DrivingDashboard was passing dateRange to trips + statistics API but NOT to odometer, time budget, or visited locations — all three fetched all-time data regardless of the selected period.

## Changes
- **analytics.py (movement-stats)**: made `from_date`/`to_date` optional; when absent returns all-time (5yr lookback). Previously `/time-budget` had no date params.
- **statistics.ts (frontend)**: `getTimeBudget()` now calls movement-stats with optional date params.
- **DrivingDashboard**: pass `fromISO`/`toISO` to `getOdometer`, `getTimeBudget`, `getVisitedLocations`.
- **DrivingDashboard**: KPI cards now show **period totals** (sum of all rows) instead of latest-day only.
- **DrivingDashboard**: historical table uses all stats rows with scrollable overflow instead of hard `slice(1,8)`.
- **MovementDashboard**: Time Budget now uses period-filtered movement-stats; badge updated from "All-time" to "Period".

## Testing
- API tests confirm movement-stats returns correct period data with date params, all-time without
- Frontend builds successfully

Closes #134