### PR TITLE
Fix: SpeedTempMatrixDashboard + backend respect dateRange filter

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -1439,6 +1439,8 @@ async def get_elevation_penalty(
 @router.get("/{vehicle_id}/analytics/speed-temp-matrix")
 async def get_speed_temp_matrix(
     vehicle_id: UUID,
+    from_date: datetime | None = Query(None),
+    to_date: datetime | None = Query(None),
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
@@ -1463,6 +1465,10 @@ async def get_speed_temp_matrix(
         Trip.avg_temp_celsius.is_not(None),
         Trip.end_date.is_not(None)
     )
+    if from_date:
+        stmt = stmt.where(Trip.start_date >= from_date)
+    if to_date:
+        stmt = stmt.where(Trip.end_date <= to_date)
 
     res = await db.execute(stmt)
     trips = res.scalars().all()

--- a/frontend/src/components/statistics/SpeedTempMatrixDashboard.tsx
+++ b/frontend/src/components/statistics/SpeedTempMatrixDashboard.tsx
@@ -53,7 +53,7 @@ class ChartErrorBoundary extends Component<{ children: ReactNode }, EBState> {
   }
 }
 
-export function SpeedTempMatrixDashboard({ vehicleId }: { vehicleId: string }) {
+export function SpeedTempMatrixDashboard({ vehicleId, dateRange }: { vehicleId: string; dateRange?: DateRangeValue }) {
   const [data, setData] = useState<SpeedTempMatrixResponse | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -62,7 +62,10 @@ export function SpeedTempMatrixDashboard({ vehicleId }: { vehicleId: string }) {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const res = await api.getSpeedTempMatrix(vehicleId);
+        const params = new URLSearchParams();
+        if (dateRange?.from) params.set("from_date", dateRange.from.toISOString());
+        if (dateRange?.to) params.set("to_date", dateRange.to.toISOString());
+        const res = await api.getSpeedTempMatrix(vehicleId, params.toString() ? `?${params}` : "");
         setData(res);
       } catch {
         // ErrorBoundary catches render errors; network errors logged server-side
@@ -71,7 +74,7 @@ export function SpeedTempMatrixDashboard({ vehicleId }: { vehicleId: string }) {
       }
     };
     fetchData();
-  }, [vehicleId]);
+  }, [vehicleId, dateRange]);
 
   if (loading) {
     return (

--- a/frontend/src/components/statistics/StatisticsShell.tsx
+++ b/frontend/src/components/statistics/StatisticsShell.tsx
@@ -212,7 +212,7 @@ export function StatisticsShell({ vehicleId }: { vehicleId: string }) {
             <ElevationPenaltyDashboard vehicleId={vehicleId} />
           </Tabs.Content>
           <Tabs.Content value="speed-temp-matrix">
-            <SpeedTempMatrixDashboard vehicleId={vehicleId} />
+            <SpeedTempMatrixDashboard vehicleId={vehicleId} dateRange={range} />
           </Tabs.Content>
           <Tabs.Content value="ice-tco">
             <IceTcoDashboard vehicleId={vehicleId} />

--- a/frontend/src/lib/api/statistics.ts
+++ b/frontend/src/lib/api/statistics.ts
@@ -229,8 +229,8 @@ export const statisticsApi = {
     return res.json();
   },
 
-  async getSpeedTempMatrix(id: string) {
-    const res = await apiFetch(`/api/v1/vehicles/${id}/analytics/speed-temp-matrix`);
+  async getSpeedTempMatrix(id: string, queryString = "") {
+    const res = await apiFetch(`/api/v1/vehicles/${id}/analytics/speed-temp-matrix${queryString}`);
     return res.json();
   },
 


### PR DESCRIPTION
### **User description**
## 📋 Summary

Fix SpeedTempMatrixDashboard + backend to respect dateRange filter. The dashboard was showing all-time data regardless of the selected period picker — a 21-day stale P0 bug.

**Related Issues:** Closes #786a38be

---

## 🧩 Type of Change

- [ ] 🆕 New feature (e.g. new dashboard, API endpoint)
- [x] 🐛 Bug fix
- [x] ⚙️ Backend change (API, collector, database)
- [x] 🎨 Frontend change (UI, charts, pages)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

- [x] Backend runs and tests pass (if applicable)
- [ ] Frontend builds
- [ ] Manual testing done

---

## 👥 Reviewer Notes

Backend API verified via curl:
- Without date params: 139 total trips in grid
- With 30-day window (2026-04-19 to 2026-05-19): 26 total trips

---

## 📌 Additional Context

Backend: analytics.py get_speed_temp_matrix() now accepts from_date/to_date Query params.
Frontend: SpeedTempMatrixDashboard accepts dateRange prop, statistics.ts passes query string, StatisticsShell passes range.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Enable date range filtering for the SpeedTempMatrix dashboard.

- Update backend API to accept and apply date filters.

- Modify frontend API client to support query parameters.

- Ensure dashboard re-fetches data when the date range changes.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Frontend
    StatisticsShell["StatisticsShell"] -- "Passes dateRange" --> SpeedTempMatrixDashboard["SpeedTempMatrixDashboard"]
    SpeedTempMatrixDashboard -- "Constructs query params" --> statisticsApi["statisticsApi"]
  end
  subgraph Backend
    statisticsApi -- "GET request with dates" --> analyticsAPI["analytics.py (API)"]
    analyticsAPI -- "SQL WHERE clause" --> DB[("Database")]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.py</strong><dd><code>Add date filtering to speed-temp-matrix backend API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/api/v1/analytics.py

<ul><li>Added <code>from_date</code> and <code>to_date</code> as optional query parameters to the <br><code>get_speed_temp_matrix</code> endpoint.<br> <li> Updated the database query to filter <code>Trip</code> records based on the <br>provided date range.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/140/files#diff-1bcd451e46734de2d8e97d41344307998190a3de95c7b5d405ec226041d1cfb3">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StatisticsShell.tsx</strong><dd><code>Pass date range state to matrix dashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/statistics/StatisticsShell.tsx

<ul><li>Passed the <code>range</code> state variable as the <code>dateRange</code> prop to the <br><code>SpeedTempMatrixDashboard</code> component.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/140/files#diff-d54d4ce1df8218f2c18ff67b47985580386cb2e50b9f414b8a1e5dd7b5bcff42">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>statistics.ts</strong><dd><code>Update statistics API client to support query strings</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/lib/api/statistics.ts

<ul><li>Modified <code>get_speed_temp_matrix</code> to accept an optional <code>queryString</code> <br>parameter.<br> <li> Appended the query string to the API fetch URL.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/140/files#diff-bc643e5fed3d67fb20df8c0a4d9270323b52b3eea60c79483820650d2282f176">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SpeedTempMatrixDashboard.tsx</strong><dd><code>Implement date range filtering in matrix dashboard component</code></dd></summary>
<hr>

frontend/src/components/statistics/SpeedTempMatrixDashboard.tsx

<ul><li>Updated the component to accept a <code>dateRange</code> prop.<br> <li> Modified <code>useEffect</code> to convert <code>dateRange</code> into URL search parameters for <br>the API call.<br> <li> Added <code>dateRange</code> to the dependency array to trigger data re-fetching on <br>filter changes.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/140/files#diff-fad3c839aee5f3580436d79c41adfdec61b8933a47e3101c47e549510eed713b">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

