### PR TITLE
Fix: use period movement-stats instead of all-time time-budget (QA-04)

### DIFF
--- a/frontend/src/components/statistics/DrivingDashboard.tsx
+++ b/frontend/src/components/statistics/DrivingDashboard.tsx
@@ -259,7 +259,7 @@ export function DrivingDashboard({ vehicleId, dateRange }: DrivingDashboardProps
         api.getStatistics(vehicleId, "day", 30, fromISO, toISO),
         // ── odometer: no date filter ── full history for mileage trend
         api.getOdometer(vehicleId, 5000),
-        api.getTimeBudget(vehicleId),
+        api.getMovementStats(vehicleId, fromISO ?? '', toISO ?? ''),
         // ── visited locations: no date filter ── all-time for map
         api.getVisitedLocations(vehicleId, 5000),
         settingsApi.getGeofences().catch(() => [] as Geofence[]),

--- a/frontend/src/components/statistics/MovementDashboard.tsx
+++ b/frontend/src/components/statistics/MovementDashboard.tsx
@@ -172,13 +172,13 @@ export function MovementDashboard({ vehicleId, dateRange }: MovementDashboardPro
   const fromISO = dateRange.from.toISOString();
   const toISO = dateRange.to.toISOString();
 
-  // All-time time budget — fetched once, not date-dependent
+  // Period time budget from movement-stats (date-range aware)
   useEffect(() => {
     setLoadingBudget(true);
-    api.getTimeBudget(vehicleId)
+    api.getMovementStats(vehicleId, fromISO, toISO)
       .then(setTimeBudget)
       .finally(() => setLoadingBudget(false));
-  }, [vehicleId]);
+  }, [vehicleId, fromISO, toISO]);
 
   // Period-based location data — refetches when date range changes
   const fetchPeriodData = useCallback(async () => {


### PR DESCRIPTION
### **User description**
## 📋 Summary

DrivingDashboard + MovementDashboard showed all-time parked/driving time regardless of selected date range (e.g. BlackMagic showed 1.8 WEEKS parked for May when actual period was 22.6 hours). Root cause: getTimeBudget(vehicleId) hits /analytics/time-budget which has no date parameters. Fix: replace with getMovementStats(vehicleId, fromISO, toISO) which correctly accepts from_date/to_date params.
<!-- 🤖 PR Agent will automatically enhance this description with detailed file walkthrough -->
<!-- ⚠️ This section must be filled out (at least 20 characters) for PR validation to pass -->

**Related Issues:** Closes #


---

## 🧩 Type of Change

<!-- Mark the relevant option with an 'x' - At least one must be checked for PR validation -->

- [ ] 🆕 New feature (e.g. new dashboard, API endpoint)
- [x] 🐛 Bug fix
- [ ] ⚙️ Backend change (API, collector, database)
- [ ] 🎨 Frontend change (UI, charts, pages)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

<!-- Mark completed items with an 'x' -->

- [ ] Backend runs and tests pass (if applicable)
- [ ] Frontend builds (`npm run build` in `frontend/`)
- [ ] Manual testing done (if applicable)

---

## 👥 Reviewer Notes

<!-- What should reviewers focus on? Any specific questions or areas of uncertainty? -->


---

## 📌 Additional Context

<!-- Any other context, links to documentation, or important notes -->


___

### **PR Type**
Bug fix


___

### **Description**
- Replace all-time budget with period-specific stats.

- Filter `DrivingDashboard` stats by selected date range.

- Update `MovementDashboard` to refetch on date change.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Dashboard["Dashboard Components"] -- "getMovementStats(id, from, to)" --> API["Analytics API"]
  API -- "Filtered Stats" --> Dashboard
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DrivingDashboard.tsx</strong><dd><code>Use date-filtered movement stats in DrivingDashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/statistics/DrivingDashboard.tsx

<ul><li>Replaced <code>api.getTimeBudget</code> with <code>api.getMovementStats</code> to include date <br>parameters.<br> <li> Ensures driving statistics reflect the selected date range.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/142/files#diff-03e1d8b1591166f59e63bb7b4698c7317559ae869fde84aea4673aff65a66f93">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MovementDashboard.tsx</strong><dd><code>Make MovementDashboard stats date-range aware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/components/statistics/MovementDashboard.tsx

<ul><li>Switched to <code>api.getMovementStats</code> with <code>fromISO</code> and <code>toISO</code> arguments.<br> <li> Added date range dependencies to the <code>useEffect</code> hook.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/142/files#diff-47c2acab04ac20ff53d1d65db640af1c4f68e0ae711d10fca7e14bb96c992018">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

