### PR TITLE
New version prepared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [v1.1.1] - 2026-06-20
+Maintenance & reliability release: fixes the charging-receipt edit lag (stale server cache), surfaces Škoda connection/auth failures in the UI so users know when to reconnect, makes the vehicle "sync off" state honest, and adds mobile-responsive fixes. Includes a statistics-correctness verification pass and a build-breaking syntax fix.
+
+### Added
+- **Connection-health surfacing**: the vehicle Settings card now shows a clear banner + badge when data collection is failing. Two states — **red "Reconnect required"** when Škoda rejects the saved login (auth/token expired), and **amber "Connection Issues"** when the vehicle is repeatedly unreachable (transient Škoda/network errors, ≥3 consecutive failed cycles). Both offer a one-click Reconnect. Backed by new `ConnectorSession` health fields populated every collection cycle and exposed on `GET /api/v1/vehicles`.
+- **Charging Mix caption** (vehicle Statistics): the AC/DC split card gained a descriptive caption ("AC vs DC · last 30 days (N sessions)") consistent with the other stat cards.
+
+### Fixed
+- **Charging-receipt edit lag (stale server cache)**: editing a charging session (provider/kWh/price) appeared to do nothing for up to 60s, then updated. Root cause: the server-side Valkey `CacheMiddleware` caches analytics GETs for 60s and the mutation never invalidated it (the `invalidate_vehicle_cache` helper existed but was dead code). `PATCH .../analytics/charging-sessions`, `PUT /vehicles/{id}`, and `DELETE /vehicles/{id}` now bust the vehicle's cache on write, so edits are reflected immediately. Verified end-to-end (GET after PATCH returns the new value with `X-Cache: MISS`).
+- **"Sync off" still showed "Active"**: disabling a vehicle's sync stopped collection (the poll job is unregistered) but left `connector_status` stuck at "active", so the badge kept reading Active. Toggling sync off now sets status **"paused"** (badge "Sync Off") and clears failure counters; re-enabling sets "pending" until the next successful poll. The Settings badge shows "Sync Off" whenever collection is disabled (covers pre-existing rows), and health banners are suppressed while paused.
+- **Silent collection failures**: the collector's `_safe()` swallowed every Škoda error and still marked the cycle "active"/fresh, so persistent failures were invisible to the user. Cycles now record success/failure honestly (`last_success_at`, `consecutive_failures`, `last_error_text`); a 401/403 flags `auth_failed`; transient errors accrue failures without forcing a reconnect prompt. Parked cycles no longer write a misleading "offline" `ConnectionState` row when Škoda was merely unreachable.
+- **Build-breaking syntax error** — `DrivingDashboard.tsx` had a comment line missing its `//` prefix (committed in `ff14ce3`), which fails the production transpile regardless of `ignoreBuildErrors`.
+- **Mobile layout** — Admin tabs now scroll horizontally instead of overflowing on small screens; the AI chat widget/launcher is repositioned (above the mobile nav bar, full-width sheet on phones, unchanged on desktop).
+
+### Changed
+- **Efficiency metric documentation** (`analytics.py`, migration `ba81d9f38011`): clarified in code that `v_advanced_trip_stats.avg_eff_*` and the overview `avg_kwh_100km` are **distance-weighted** consumption (`SUM(kwh)/SUM(distance)*100`), not an average of per-trip ratios, and marked the superseded `AVG`-of-ratios migration obsolete (the fix landed in `93b2a201b1a4`). Documentation only — no value change. Confirmed the live overview numbers (battery, range, odometer, trip mix, efficiency, €/kWh) match the raw database.
+
+### Database
+- `c7d8e9f0a1b2_add_connector_health_fields.py` — adds `last_success_at` (timestamptz), `consecutive_failures` (int, default 0), and `last_error_text` (varchar 255) to `connector_sessions`. New migration head; no data backfill required.
+
 ## [v1.1.0] - 2026-06-14
 Minor release: AI assistant goes production-grade — streamed chat answers,
 admin-controlled RAG embedding backfill, and a safe production-restore migration

--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -16,6 +16,7 @@ from app.models.telemetry import Trip, ChargingSession, VehiclePosition, Chargin
 from app.models.user import User
 from app.models.vehicle import UserVehicle
 from app.schemas.telemetry import PulseResponse
+from app.services.cache import invalidate_vehicle_cache
 
 from pydantic import BaseModel
 
@@ -150,6 +151,10 @@ async def update_charging_session(
         session_obj.provider_name = payload.provider_name
         
     await db.commit()
+    # Bust the server-side Valkey cache so the edit is reflected immediately.
+    # Without this, CacheMiddleware keeps serving the stale pre-edit response
+    # (X-Cache: HIT) for up to its 60s TTL.
+    await invalidate_vehicle_cache(str(vehicle_id))
     return {"status": "success", "message": "Charging session updated"}
 
 
@@ -795,6 +800,13 @@ async def get_advanced_analytics_overview(
     await get_user_vehicle(user.id, vehicle_id, db)
 
     # 1. Trip Stats
+    # NOTE: the avg_eff_* columns are DISTANCE-WEIGHTED consumption, i.e.
+    # SUM(kwh_consumed) / SUM(distance_km) * 100 — NOT an average of per-trip
+    # ratios. This is the physically correct "average kWh/100km". The naive
+    # AVG(kwh/dist*100) over-weights short low-SoC-delta trips and inflates the
+    # figure (~29 vs the correct ~24 here). See migration 93b2a201b1a4
+    # (fix_advanced_trip_stats_math), which superseded the original AVG-of-ratios
+    # view from ba81d9f38011. Do not "simplify" this back to AVG().
     trip_sql = text("""
         SELECT short_trips_count, medium_trips_count, long_trips_count, total_trips,
                avg_eff_cold, avg_eff_warm, avg_eff_overall
@@ -865,6 +877,7 @@ async def get_advanced_analytics_overview(
     # Build response with dynamic data and safe fallbacks
     return {
         "efficiency": {
+            # Distance-weighted consumption (total kWh / total km * 100); see trip_sql note above.
             "avg_kwh_100km": round(overall_eff, 1),
             "cold_penalty_pct": round(cold_penalty, 1),
             "cold_eff_kwh_100km": round(cold_eff, 1),

--- a/backend/app/api/v1/vehicles.py
+++ b/backend/app/api/v1/vehicles.py
@@ -58,6 +58,7 @@ from app.schemas.telemetry import (
     WLTPResponse,
 )
 from app.schemas.vehicle import VehicleCreate, VehicleResponse, VehicleStatusResponse, VehicleUpdate, VehicleReauth, TopPlaceItem
+from app.services.cache import invalidate_vehicle_cache
 from app.services.crypto import decrypt_field, encrypt_field, hash_field
 from app.services.events import publish_vehicle_deleted, publish_vehicle_linked, publish_vehicle_refresh, publish_vehicle_updated
 from app.services.external_apis import reverse_geocode_address
@@ -182,6 +183,9 @@ def _vehicle_to_response(v: UserVehicle) -> VehicleResponse:
         warning_lights=v.warning_lights,
         connector_status=cs.status if cs else None,
         last_fetch_at=cs.last_fetch_at if cs else None,
+        last_success_at=cs.last_success_at if cs else None,
+        consecutive_failures=cs.consecutive_failures if cs else 0,
+        last_error_text=cs.last_error_text if cs else None,
         created_at=v.created_at,
     )
 
@@ -302,8 +306,27 @@ async def update_vehicle(
     update_data = body.model_dump(exclude_unset=True)
     for field, value in update_data.items():
         setattr(vehicle, field, value)
+
+    # Reflect a sync on/off toggle on the connector status so the UI doesn't keep
+    # showing "Active" after the user pauses collection. The collector unregisters
+    # the polling job on disable (publish_vehicle_updated below), so nothing would
+    # otherwise reset the sticky status. On re-enable we mark it "pending" until the
+    # next successful poll flips it back to "active".
+    cs = vehicle.connector_session
+    if cs and "collection_enabled" in update_data:
+        if update_data["collection_enabled"] is False:
+            cs.status = "paused"
+            cs.consecutive_failures = 0
+            cs.last_error_text = None
+        elif cs.status == "paused":
+            cs.status = "pending"
+
     await db.commit()
     await db.refresh(vehicle)
+
+    # Bust the server-side Valkey cache so edited vehicle details show up
+    # immediately instead of after CacheMiddleware's 60s TTL.
+    await invalidate_vehicle_cache(str(vehicle.id))
 
     await publish_vehicle_updated(
         str(vehicle.id),
@@ -323,6 +346,7 @@ async def delete_vehicle(
     vid = str(vehicle.id)
     await db.delete(vehicle)
     await db.commit()
+    await invalidate_vehicle_cache(vid)
     await publish_vehicle_deleted(vid)
 
 

--- a/backend/app/migrations/versions/ba81d9f38011_add_advanced_analytics_views.py
+++ b/backend/app/migrations/versions/ba81d9f38011_add_advanced_analytics_views.py
@@ -18,6 +18,10 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     # View for Trip Type and Weather Impact Analytics
+    # ⚠️ SUPERSEDED: the avg_eff_* AVG-of-ratios math below was replaced by
+    # distance-weighted SUM(kwh)/SUM(dist)*100 in migration 93b2a201b1a4
+    # (fix_advanced_trip_stats_math). This historical version is kept as-is for
+    # the migration chain — do NOT copy its efficiency formula.
     op.execute("""
     CREATE OR REPLACE VIEW v_advanced_trip_stats AS
     SELECT 

--- a/backend/app/migrations/versions/c7d8e9f0a1b2_add_connector_health_fields.py
+++ b/backend/app/migrations/versions/c7d8e9f0a1b2_add_connector_health_fields.py
@@ -1,0 +1,36 @@
+"""Add connector health fields (last_success_at, consecutive_failures, last_error_text)."""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "c7d8e9f0a1b2"
+down_revision = "b7e4f1a9c2d8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "connector_sessions",
+        sa.Column("last_success_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "connector_sessions",
+        sa.Column(
+            "consecutive_failures",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "connector_sessions",
+        sa.Column("last_error_text", sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("connector_sessions", "last_error_text")
+    op.drop_column("connector_sessions", "consecutive_failures")
+    op.drop_column("connector_sessions", "last_success_at")

--- a/backend/app/models/vehicle.py
+++ b/backend/app/models/vehicle.py
@@ -117,5 +117,11 @@ class ConnectorSession(TimestampMixin, Base):
     token_expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     last_fetch_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     status: Mapped[str] = mapped_column(String(20), default="pending", nullable=False)
+    # Connection health: last_success_at = last cycle that actually reached Škoda
+    # (parked or active), consecutive_failures counts cycles that couldn't reach it,
+    # last_error_text is a short human-readable reason for the most recent failure.
+    last_success_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    consecutive_failures: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    last_error_text: Mapped[str | None] = mapped_column(String(255))
 
     user_vehicle: Mapped["UserVehicle"] = relationship(back_populates="connector_session")

--- a/backend/app/schemas/vehicle.py
+++ b/backend/app/schemas/vehicle.py
@@ -43,6 +43,10 @@ class VehicleResponse(BaseModel):
     warning_lights: list[dict] | None = None
     connector_status: str | None = None
     last_fetch_at: datetime | None = None
+    # Connection health
+    last_success_at: datetime | None = None
+    consecutive_failures: int = 0
+    last_error_text: str | None = None
     created_at: datetime
     # Efficiency calibration
     charger_power_kw: float | None = None

--- a/backend/app/services/collector.py
+++ b/backend/app/services/collector.py
@@ -463,6 +463,7 @@ class DataCollector:
             vin = decrypt_field(vehicle.vin_encrypted)
             api = SkodaAPIClient(access_token)
             now = datetime.now(UTC)
+            cycle_errors: list = []  # collected by _safe; drives connection-health bookkeeping
 
             try:
                 # ══════════════════════════════════════════════════════════════
@@ -480,7 +481,7 @@ class DataCollector:
                 # ══════════════════════════════════════════════════════════════
 
                 # ── Step 1: Connection status (always, 1 API call) ──────────
-                conn_resp = await _safe(api.get_connection_status(vin), "connection_status", user_vehicle_id)
+                conn_resp = await _safe(api.get_connection_status(vin), "connection_status", user_vehicle_id, cycle_errors)
 
                 is_online = conn_resp and not conn_resp.unreachable
                 is_moving = conn_resp and (conn_resp.in_motion or conn_resp.ignition_on)
@@ -503,7 +504,7 @@ class DataCollector:
                 if is_online:
                     if not is_moving:
                         # Not moving — check charging (2nd API call)
-                        charging = await _safe(api.get_charging(vin), "charging", user_vehicle_id)
+                        charging = await _safe(api.get_charging(vin), "charging", user_vehicle_id, cycle_errors)
                         is_charging = (
                             charging and charging.status
                             and charging.status.state == "CHARGING"
@@ -511,7 +512,7 @@ class DataCollector:
 
                         if not is_charging:
                             # Not moving, not charging — check AC (3rd API call)
-                            ac_resp = await _safe(api.get_air_conditioning(vin), "air_conditioning", user_vehicle_id)
+                            ac_resp = await _safe(api.get_air_conditioning(vin), "air_conditioning", user_vehicle_id, cycle_errors)
                             is_ac_on = (
                                 ac_resp is not None
                                 and ac_resp.state is not None
@@ -566,7 +567,10 @@ class DataCollector:
                     last_known = self._last_connection_state.get(user_vehicle_id)
                     state_changed = (last_known is None) or (last_known != is_online)
 
-                    if state_changed:
+                    # Only record a ConnectionState row on a real, observed status change.
+                    # Skip when conn_resp is None: we couldn't reach Škoda this cycle, so we
+                    # don't actually know the car went offline (avoids false "offline" rows).
+                    if state_changed and conn_resp is not None:
                         session.add(ConnectionState(
                             user_vehicle_id=user_vehicle_id,
                             captured_at=now,
@@ -575,20 +579,20 @@ class DataCollector:
                             ignition_on=conn_resp.ignition_on if conn_resp else None,
                         ))
                         self._last_connection_state[user_vehicle_id] = is_online
-                        cs.status = "active"
-                        await session.commit()
                         logger.info(
                             "Smart poll: vehicle %s PARKED — state changed (was=%s → now online=%s). "
                             "ConnectionState saved.",
                             user_vehicle_id, last_known, is_online,
                         )
                     else:
-                        # No state change → nothing to persist; skip DB round-trip entirely.
                         logger.debug(
-                            "Smart poll: vehicle %s PARKED (online=%s, unchanged). "
-                            "Skipping DB write.",
+                            "Smart poll: vehicle %s PARKED (online=%s, unchanged or unreachable).",
                             user_vehicle_id, is_online,
                         )
+                    # Refresh connection-health every cycle (one cheap UPDATE) so the UI can
+                    # detect when we stop being able to reach the vehicle.
+                    _apply_health(cs, conn_resp is not None, cycle_errors, now)
+                    await session.commit()
                     return
 
                 # ══════════════════════════════════════════════════════════════
@@ -601,23 +605,23 @@ class DataCollector:
 
                 # Fetch charging if we didn't already (car was detected moving in step 2)
                 if charging is None:
-                    charging = await _safe(api.get_charging(vin), "charging", user_vehicle_id)
+                    charging = await _safe(api.get_charging(vin), "charging", user_vehicle_id, cycle_errors)
 
-                driving = await _safe(api.get_driving_range(vin), "driving_range", user_vehicle_id)
-                
+                driving = await _safe(api.get_driving_range(vin), "driving_range", user_vehicle_id, cycle_errors)
+
                 position = None
                 if not vehicle.incognito_mode:
-                    position = await _safe(api.get_position(vin), "position", user_vehicle_id)
-                
-                status_resp = await _safe(api.get_vehicle_status(vin), "vehicle_status", user_vehicle_id)
+                    position = await _safe(api.get_position(vin), "position", user_vehicle_id, cycle_errors)
+
+                status_resp = await _safe(api.get_vehicle_status(vin), "vehicle_status", user_vehicle_id, cycle_errors)
                 if not ac_resp:
-                    ac_resp = await _safe(api.get_air_conditioning(vin), "air_conditioning", user_vehicle_id)
-                maint_resp = await _safe(api.get_maintenance(vin), "maintenance", user_vehicle_id)
-                warning_lights_resp = await _safe(api.get_warning_lights(vin), "warning_lights", user_vehicle_id)
-                
+                    ac_resp = await _safe(api.get_air_conditioning(vin), "air_conditioning", user_vehicle_id, cycle_errors)
+                maint_resp = await _safe(api.get_maintenance(vin), "maintenance", user_vehicle_id, cycle_errors)
+                warning_lights_resp = await _safe(api.get_warning_lights(vin), "warning_lights", user_vehicle_id, cycle_errors)
+
                 # Fetch additional metadata endpoints for complete raw data coverage
-                garage_vehicle_resp = await _safe(api.get_garage_vehicle(vin), "garage_vehicle", user_vehicle_id)
-                vehicle_renders_resp = await _safe(api.get_vehicle_renders(vin), "vehicle_renders", user_vehicle_id)
+                garage_vehicle_resp = await _safe(api.get_garage_vehicle(vin), "garage_vehicle", user_vehicle_id, cycle_errors)
+                vehicle_renders_resp = await _safe(api.get_vehicle_renders(vin), "vehicle_renders", user_vehicle_id, cycle_errors)
 
                 # Weather & elevation for position enrichment
                 temp_c = None
@@ -1072,7 +1076,10 @@ class DataCollector:
 
                 # ── Commit & update timestamp ───────────────────────────────
                 cs.last_fetch_at = now
-                cs.status = "active"
+                # Connection-health: in the ACTIVE path we reached Škoda (the step-1
+                # connection probe returned), so this records success / clears any prior
+                # failure — unless a data call returned 401/403, which flags auth_failed.
+                _apply_health(cs, conn_resp is not None, cycle_errors, now)
                 await session.commit()
                 logger.info("Collection complete for vehicle %s (ACTIVE full fetch)", user_vehicle_id)
 
@@ -1225,12 +1232,46 @@ async def _update_or_insert_duration_state(
     session.add(model_cls(**insert_data))
 
 
-async def _safe(coro, label: str, vehicle_id: UUID):
+async def _safe(coro, label: str, vehicle_id: UUID, errors: list | None = None):
     try:
         return await coro
-    except Exception:
+    except Exception as e:
+        status_code = e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None
         logger.warning("Failed to fetch %s for vehicle %s", label, vehicle_id, exc_info=True)
+        if errors is not None:
+            errors.append({"label": label, "status": status_code})
         return None
+
+
+def _apply_health(cs, reached: bool, cycle_errors: list, now) -> None:
+    """Update ConnectorSession health bookkeeping after a collection cycle.
+
+    `reached` = we successfully contacted Škoda this cycle (the connection_status
+    probe returned). A 401/403 anywhere means the saved login was rejected and the
+    user must reconnect. Anything else that prevented contact is a transient/server
+    issue surfaced via consecutive_failures + last_error_text without forcing reauth.
+    """
+    auth_rejected = any(e.get("status") in (401, 403) for e in cycle_errors)
+    if auth_rejected:
+        cs.status = "auth_failed"
+        cs.consecutive_failures = (cs.consecutive_failures or 0) + 1
+        cs.last_error_text = "Škoda rejected the saved login (authentication failed) — please reconnect."
+        return
+    if reached:
+        cs.last_success_at = now
+        cs.consecutive_failures = 0
+        cs.status = "active"
+        cs.last_error_text = None
+    else:
+        cs.consecutive_failures = (cs.consecutive_failures or 0) + 1
+        first = next((e for e in cycle_errors if e.get("status")), None)
+        if first:
+            cs.last_error_text = f"Couldn't reach Škoda ({first['label']}: HTTP {first['status']})"[:255]
+        elif cycle_errors:
+            cs.last_error_text = f"Couldn't reach Škoda ({cycle_errors[0]['label']})"[:255]
+        else:
+            cs.last_error_text = "Couldn't reach the Škoda service."
+        # Leave cs.status untouched — don't claim "active" when we never made contact.
 
 
 def _debug_summary(charging, driving, conn_resp) -> dict:

--- a/frontend/src/app/(dashboard)/admin/page.tsx
+++ b/frontend/src/app/(dashboard)/admin/page.tsx
@@ -440,7 +440,7 @@ export default function AdminPage() {
       </div>
 
       {/* Tabs */}
-      <div className="flex gap-1 bg-iv-surface/50 rounded-lg p-1 w-fit">
+      <div className="flex gap-1 bg-iv-surface/50 rounded-lg p-1 w-fit max-w-full overflow-x-auto no-scrollbar">
         {(
           [
             { id: "statistics" as Tab, label: "Statistics", icon: Activity, badge: 0 },
@@ -453,7 +453,7 @@ export default function AdminPage() {
           <button
             key={t.id}
             onClick={() => setTab(t.id)}
-            className={`flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-all ${
+            className={`flex shrink-0 items-center gap-2 px-4 py-2 rounded-md text-sm font-medium whitespace-nowrap transition-all ${
               tab === t.id
                 ? "bg-iv-charcoal text-iv-text shadow-sm"
                 : "text-iv-muted hover:text-iv-text"

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -25,6 +25,7 @@ import {
   RefreshCcw,
   Eye,
   EyeOff,
+  AlertTriangle,
 } from "lucide-react";
 import Image from "next/image";
 import { useAuth } from "@/lib/auth-context";
@@ -45,6 +46,9 @@ interface SettingsVehicle {
   country_code: string | null;
   connector_status: string | null;
   last_fetch_at: string | null;
+  last_success_at: string | null;
+  consecutive_failures: number;
+  last_error_text: string | null;
   created_at: string;
   // Efficiency calibration
   charger_power_kw: number | null;
@@ -115,9 +119,63 @@ function ConnectorStatusBadge({ status }: { status: string | null }) {
     pending: { color: "bg-iv-warning/15 text-iv-warning border-iv-warning/20", label: "Pending" },
     auth_failed: { color: "bg-iv-danger/15 text-iv-danger border-iv-danger/20", label: "Auth Failed" },
     token_error: { color: "bg-iv-danger/15 text-iv-danger border-iv-danger/20", label: "Token Error" },
+    degraded: { color: "bg-iv-warning/15 text-iv-warning border-iv-warning/20", label: "Connection Issues" },
+    paused: { color: "bg-iv-surface text-iv-muted border-iv-border", label: "Sync Off" },
   };
   const cfg = map[status] || { color: "bg-iv-surface text-iv-muted border-iv-border", label: status };
   return <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${cfg.color}`}>{cfg.label}</span>;
+}
+
+/** Derives a user-facing connection-health alert from the vehicle's connector health fields. */
+function vehicleConnectionAlert(v: SettingsVehicle): { level: "auth" | "degraded"; title: string; detail: string } | null {
+  // Sync intentionally paused — no reconnect/degraded prompts apply.
+  if (!v.collection_enabled) return null;
+  if (v.connector_status === "token_error" || v.connector_status === "auth_failed") {
+    return {
+      level: "auth",
+      title: "Reconnect required",
+      detail: v.last_error_text
+        || "Your Škoda login has expired or was rejected. Please reconnect your account to resume data collection.",
+    };
+  }
+  // Persistent inability to reach the vehicle (transient Škoda outage / network).
+  if (v.collection_enabled && (v.consecutive_failures ?? 0) >= 3) {
+    const since = v.last_success_at ? new Date(v.last_success_at).toLocaleString() : "a while ago";
+    return {
+      level: "degraded",
+      title: "Can't reach your vehicle",
+      detail: `${v.last_error_text || "We're having trouble reaching the Škoda service."} Last successful sync: ${since}. This often resolves on its own; if it keeps happening, try reconnecting.`,
+    };
+  }
+  return null;
+}
+
+function ConnectionAlert({ v, onReconnect }: { v: SettingsVehicle; onReconnect: () => void }) {
+  const alert = vehicleConnectionAlert(v);
+  if (!alert) return null;
+  const isAuth = alert.level === "auth";
+  const box = isAuth
+    ? "border-iv-danger/30 bg-iv-danger/10 text-iv-danger"
+    : "border-iv-warning/30 bg-iv-warning/10 text-iv-warning";
+  const btn = isAuth
+    ? "border-iv-danger/40 hover:bg-iv-danger/15"
+    : "border-iv-warning/40 hover:bg-iv-warning/15";
+  return (
+    <div className={`flex items-start gap-2.5 rounded-lg border px-3 py-2.5 ${box}`}>
+      <AlertTriangle size={16} className="mt-0.5 flex-shrink-0" />
+      <div className="flex-1 min-w-0">
+        <p className="text-xs font-semibold">{alert.title}</p>
+        <p className="mt-0.5 text-xs opacity-90 break-words">{alert.detail}</p>
+      </div>
+      <button
+        onClick={onReconnect}
+        className={`flex-shrink-0 inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs font-medium transition-colors ${btn}`}
+      >
+        <RefreshCcw size={13} />
+        Reconnect
+      </button>
+    </div>
+  );
 }
 
 export default function SettingsPage() {
@@ -472,7 +530,13 @@ export default function SettingsPage() {
                       <p className="text-sm font-medium text-iv-text break-words">
                         {v.display_name || `${v.manufacturer || ""} ${v.model || ""}`.trim() || "Vehicle"}
                       </p>
-                      <ConnectorStatusBadge status={v.connector_status} />
+                      <ConnectorStatusBadge status={
+                        !v.collection_enabled
+                          ? "paused"
+                          : v.connector_status === "active" && (v.consecutive_failures ?? 0) >= 3
+                            ? "degraded"
+                            : v.connector_status
+                      } />
                     </div>
                     {/* Dates – stacked on mobile, inline on sm+ */}
                     <div className="mt-1 grid grid-cols-1 gap-0.5 sm:block">
@@ -488,7 +552,7 @@ export default function SettingsPage() {
                   </div>
 
                   {/* Remove button – icon-only on mobile, icon+label on sm+ */}
-                  {v.connector_status === "token_error" && (
+                  {(v.connector_status === "token_error" || v.connector_status === "auth_failed") && (
                     <button
                       onClick={() => {
                         setReauthUsername("");
@@ -521,6 +585,17 @@ export default function SettingsPage() {
                     <span className="hidden sm:inline">Calibrate</span>
                   </button>
                 </div>
+
+                {/* ── Connection-health alert (auth expired / can't reach vehicle) ── */}
+                <ConnectionAlert
+                  v={v}
+                  onReconnect={() => {
+                    setReauthUsername("");
+                    setReauthPassword("");
+                    setReauthSpin("");
+                    setReauthModalId(v.id);
+                  }}
+                />
 
                 {/* ── Intervals row ── */}
                 <div className="flex items-start gap-2 pl-0 sm:pl-11">

--- a/frontend/src/app/(dashboard)/vehicles/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/vehicles/[id]/page.tsx
@@ -948,6 +948,9 @@ export default function VehicleDetailPage() {
         const totalKm = recentTrips.reduce((acc, t) => acc + ((t as any).distance_km ?? (t.end_odometer && t.start_odometer ? t.end_odometer - t.start_odometer : 0)), 0);
         const totalChargedKwh = recentSessions.reduce((acc, s) => acc + (s.energy_kwh || 0), 0);
         
+        // Charging Mix: AC vs DC split of the last 30 days' charging sessions (by count, not energy).
+        // acPercent = sessions explicitly tagged "AC"; dcPercent is the remainder, so any session
+        // with a null/unknown charging_type is counted as DC.
         const acCount = recentSessions.filter(s => s.charging_type === "AC").length;
         const totalSessionsCount = recentSessions.length;
         const acPercent = totalSessionsCount > 0 ? Math.round((acCount / totalSessionsCount) * 100) : 0;
@@ -1025,6 +1028,9 @@ export default function VehicleDetailPage() {
                       <span className="font-semibold text-iv-text">{dcPercent}% DC</span>
                     </div>
                   </div>
+                </div>
+                <div className="mt-3 flex items-center gap-2 text-xs font-medium text-iv-muted">
+                  <span>AC vs DC · last 30 days ({totalSessionsCount} sessions)</span>
                 </div>
               </div>
 

--- a/frontend/src/components/chat/IVDriveAIWidget.tsx
+++ b/frontend/src/components/chat/IVDriveAIWidget.tsx
@@ -238,7 +238,7 @@ export function IVDriveAIWidget() {
     return (
       <button
         onClick={() => setIsOpen(true)}
-        className="fixed bottom-6 right-6 z-50 w-[60px] h-[60px] rounded-full bg-[#007AFF] shadow-xl shadow-blue-500/30 hover:scale-105 hover:shadow-2xl transition-all duration-300 flex items-center justify-center group border border-white/10 backdrop-blur-md"
+        className="fixed bottom-20 right-4 md:bottom-6 md:right-6 z-50 w-[60px] h-[60px] rounded-full bg-[#007AFF] shadow-xl shadow-blue-500/30 hover:scale-105 hover:shadow-2xl transition-all duration-300 flex items-center justify-center group border border-white/10 backdrop-blur-md"
         aria-label="Open iVDrive AI Assistant"
       >
         {unread && (
@@ -250,7 +250,7 @@ export function IVDriveAIWidget() {
   }
 
   return (
-    <div className="fixed bottom-6 right-6 z-50 w-[400px] h-[600px] flex flex-col bg-iv-charcoal/80 dark:bg-iv-black/80 backdrop-blur-2xl border border-iv-border rounded-[2rem] shadow-2xl overflow-hidden animate-in slide-in-from-bottom-4 duration-300 ease-out">
+    <div className="fixed inset-x-3 bottom-20 top-16 md:inset-auto md:top-auto md:bottom-6 md:right-6 z-50 w-auto md:w-[400px] h-auto md:h-[600px] flex flex-col bg-iv-charcoal/80 dark:bg-iv-black/80 backdrop-blur-2xl border border-iv-border rounded-[2rem] shadow-2xl overflow-hidden animate-in slide-in-from-bottom-4 duration-300 ease-out">
       {/* Header */}
       <div className="flex items-center justify-between px-5 py-4 border-b border-iv-border bg-iv-charcoal/40 dark:bg-iv-black/20 shrink-0">
         <div className="flex items-center gap-3">

--- a/frontend/src/components/statistics/DrivingDashboard.tsx
+++ b/frontend/src/components/statistics/DrivingDashboard.tsx
@@ -319,7 +319,7 @@ export function DrivingDashboard({ vehicleId, dateRange }: DrivingDashboardProps
   const totalSessions = periodTotals ? String(periodTotals.charging_sessions_count) : "—";
 
 
-Mileage trend chart data (last 60 odometer readings, reversed → chronological)
+  // Mileage trend chart data (last 60 odometer readings, reversed → chronological)
   // Uses timestamp ms as x-axis value so Recharts can compute proper domain/spacing
   // regardless of how many unique date labels exist
   const mileageChartData = useMemo(() => {


### PR DESCRIPTION
## 📋 Summary

**Release v1.1.1 — connection transparency & data-freshness fixes.**

This PR makes vehicle data freshness reliable and tells users when something is actually wrong, instead of failing silently:

- **Charging-receipt edits update instantly.** The server-side Valkey `CacheMiddleware` caches analytics GETs for 60s and the mutation endpoints never invalidated it (the `invalidate_vehicle_cache` helper existed but was dead code), so receipt/stat edits appeared to lag up to ~60s. `PATCH .../analytics/charging-sessions`, `PUT /vehicles/{id}`, and `DELETE /vehicles/{id}` now bust the vehicle's cache on write.
- **Connection-health surfacing.** The vehicle **Settings** card now shows a **red "Reconnect required"** banner when Škoda rejects the saved login, or an **amber "Connection Issues"** banner when the car is repeatedly unreachable — both with a one-click Reconnect. The collector previously swallowed Škoda errors and still marked every cycle "active", so failures were invisible.
- **"Sync off" no longer shows "Active".** Disabling sync stopped collection but left `connector_status` stuck at "active"; it now resolves to a **"Sync Off"** state.
- **Statistics correctness verified** against the raw DB (overview numbers match), efficiency-metric documentation clarified (distance-weighted, not avg-of-ratios), and a **build-breaking syntax error** in `DrivingDashboard.tsx` fixed.

**Related Issues:** Closes #

---

## 🧩 Type of Change

- [x] 🆕 New feature (e.g. new dashboard, API endpoint)
- [x] 🐛 Bug fix
- [x] ⚙️ Backend change (API, collector, database)
- [x] 🎨 Frontend change (UI, charts, pages)
- [x] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

- [x] Backend runs and tests pass (if applicable) — `ast.parse` + `app.main` import clean; `_apply_health` unit-tested across 5 branches; migration applied to a live DB
- [x] Frontend builds (`npm run build` in `frontend/`)
- [x] Manual testing done (if applicable) — see below

Manual/E2E checks performed:
- Cache fix: GET after PATCH returns the new value with `X-Cache: MISS` (was `HIT` with stale value).
- Sync toggle via `PUT /vehicles/{id}`: `connector_status` goes active → `paused` (off) → `pending` (on).
- Connection health: degraded state confirmed surfacing through `GET /vehicles`.
- Overview stats verified equal to an independent raw-DB recompute (trip mix 89/8.3/2.7%, efficiency 24.0 kWh/100km distance-weighted, user €/kWh exact).

---

## 👥 Reviewer Notes

- **DB migration** `c7d8e9f0a1b2_add_connector_health_fields.py` adds 3 additive columns to `connector_sessions` (`last_success_at`, `consecutive_failures`, `last_error_text`). New head `b7e4f1a9c2d8 → c7d8e9f0a1b2`. No backfill.
- **Collector behavior change:** `_apply_health()` runs every cycle and `last_success_at` only advances when Škoda was actually reached (previously the cycle unconditionally marked itself "active"). Parked cycles now also commit a lightweight health update every poll and no longer write a false "offline" `ConnectionState` row when the car was merely unreachable — worth a sanity check on parked-vehicle write volume.
- **Cache invalidation** is wired into all vehicle mutation endpoints — confirm no other write path serves stale analytics.
- **Deploy requirement:** containers run **baked images** (only `shared_data` is bind-mounted). All three images (`api`, `web`, `collector`) must be rebuilt — the collector carries the new health logic, so a pull/API-only rebuild is not enough.

---

## 📌 Additional Context

- Full notes: `CHANGELOG.md` (`[v1.1.1]`) and `_local_docs/releases/release_new_version.md`.
- Upgrade: rebuild + push `m7xlab/ivdrive-{api,web,collector}` at `v1.1.1`, then `alembic upgrade head` (in-container: `PYTHONPATH=/app alembic upgrade head`). No new env vars, no compose changes.
- Documentation-only edit to migration `ba81d9f38011` (marks the superseded `AVG`-of-ratios efficiency view obsolete; the math fix already shipped in `93b2a201b1a4`).
