### PR TITLE
fix(migrations): merge v1.1.2 alembic heads (production hotfix)

### DIFF
--- a/backend/app/migrations/versions/b1c2d3e4f5g6_merge_v1_1_2_heads.py
+++ b/backend/app/migrations/versions/b1c2d3e4f5g6_merge_v1_1_2_heads.py
@@ -1,0 +1,40 @@
+"""merge v1.1.2 alembic heads.
+
+Production was blocked on `alembic upgrade head` with:
+
+    Multiple head revisions are present for given argument 'head'
+
+Two heads existed after merging release/v1.1.2 -> main:
+  - c7d8e9f0a1b2 (v1.1.1 connector health fields — already in prod)
+  - a1b2c3d4e5g7 (v1.1.2 battery SoH ops model — needs to apply)
+
+Both chains share a common ancestor at b2c3d4e5f6a8 but were never
+re-unified by a merge migration in v1.1.2.
+
+This is a pure merge: no schema changes, alembic just records that
+both lineages are now unified.
+
+Revision ID: b1c2d3e4f5g6
+Revises: c7d8e9f0a1b2, a1b2c3d4e5g7
+Create Date: 2026-07-03 17:40:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "b1c2d3e4f5g6"
+down_revision: Union[str, tuple, None] = ("c7d8e9f0a1b2", "a1b2c3d4e5g7")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Pure merge — no schema changes.
+    pass
+
+
+def downgrade() -> None:
+    # Pure merge — no schema changes.
+    pass

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -489,6 +489,12 @@ export default function SettingsPage() {
   }, []);
 
   useEffect(() => {
+    loadVehicles();
+    loadGeofences();
+    loadExportJobs();
+  }, [loadVehicles, loadGeofences, loadExportJobs]);
+
+  useEffect(() => {
     const hasPending = exportJobs.some(j => j.status === "PENDING" || j.status === "PROCESSING");
 
     if (hasPending) {

--- a/frontend/src/components/vehicle-card.tsx
+++ b/frontend/src/components/vehicle-card.tsx
@@ -13,9 +13,6 @@ import {
   Battery,
 
   MapPin,
-
-  Clock,
-
   Trash2,
 
   Loader2,
@@ -32,9 +29,7 @@ import {
 
   Zap,
 
-  ChevronRight,
-
-} from "lucide-react";
+  ChevronRight} from "lucide-react";
 
 
 
@@ -578,13 +573,7 @@ export function VehicleCard({
 
           </div>
 
-          <span className="flex items-center gap-1 text-xs text-iv-muted whitespace-nowrap flex-shrink-0 pt-1">
-
-            <Clock size={11} />
-
-            {formatTimeAgo(status?.last_updated ?? null)}
-
-          </span>
+          
 
         </div>
 


### PR DESCRIPTION
## 📋 Summary

Two post-mortem hotfixes for v1.1.2:

### 1. `alembic upgrade head` failed in production with "Multiple head revisions"
Two alembic heads existed after merging release/v1.1.2 → main:
- `c7d8e9f0a1b2` (v1.1.1 connector health fields)
- `a1b2c3d4e5g7` (v1.1.2 battery SoH ops model)

PR #161's merge didn't generate the merge migration alembic expects. Fix: new pure-merge migration `b1c2d3e4f5g6_merge_v1_1_2_heads.py` with `down_revision = (c7d8e9f0a1b2, a1b2c3d4e5g7)`.

### 2. Frontend regressions from the react-doctor cleanup
- **settings/page.tsx** — the `useEffect` that called `loadVehicles()`, `loadGeofences()`, `loadExportJobs()` on mount was deleted. Both sections hung on loading spinners forever. Restored verbatim from v1.1.1.
- **vehicle-card.tsx** — the top-right "X ago" timestamp duplicates the timestamp inside the new `DataHealthBadge` ("Stale · 1h ago" / "Live · just now" / "Down · 3d ago"). Removed the standalone timestamp + unused `Clock` import.

## 🧩 Type of Change

- [x] 🐛 Bug fix (alembic + 2 frontend regressions)
- [x] ⚙️ Backend change (migration)
- [x] 🎨 Frontend change

## ✅ Validation

- [x] `alembic upgrade head` succeeds (already live in prod as out-of-band patch)
- [x] `npx next build` exits 0, all 10 routes compile + generate
- [x] Data-health endpoint serves 200 OK to real users

## 👥 Reviewer Notes

- 2 commits on `fix/v1.1.2` (both by M7xBeast, both verified with `next build` / `alembic upgrade`)
- The alembic merge is **already live in production** (applied out-of-band because the release was down). The frontend fixes are not yet in production — that needs an image rebuild + push after this PR merges.
- Files: 3 files, +56 / −13

Generated by iVDrive Team ®
