### PR TITLE
feat(security): add Content-Security-Policy header

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -24,16 +24,21 @@ const nextConfig = {
     // analytics host is included only when SITE_ANALYTICS_URL is configured.
     // Directives:
     //   default-src 'self'                         — baseline
-    //   script-src 'self' 'unsafe-inline' + maps   — Next.js RSC streaming emits inline
-    //                                              __next_f.push() scripts in production;
-    //                                              Leaflet marker icons served from unpkg;
-    //                                              CARTO basemap served from *.basemaps.cartocdn.com.
+    //   script-src 'self' 'unsafe-inline' + analytics — Next.js RSC streaming emits inline
+    //                                              __next_f.push() scripts in production.
     //                                              'unsafe-inline' is unfortunately required by Next.js 16
     //                                              unless we move to nonce-based CSP (separate pass).
+    //                                              Map tile domains (unpkg, cartocdn) belong ONLY in
+    //                                              img-src — they serve image assets, never JS.
+    //                                              Allowing arbitrary scripts from those CDNs would
+    //                                              escalate any XSS into a full CDN-level hijack.
+    //                                              (PR Agent #163 finding.)
     //   style-src 'self' 'unsafe-inline' + gfont CSS — Inter from Google Fonts
-    //   img-src 'self' data: blob: + maps tiles      — CARTO + Leaflet
+    //   img-src 'self' data: blob: + maps tiles      — CARTO basemap tiles + Leaflet marker icons (unpkg)
     //   font-src 'self' data: + gstatic             — Inter font files
-    //   connect-src 'self'                           — all API calls via Next.js rewrites
+    //   connect-src 'self' + analytics host         — API calls via Next.js rewrites;
+    //                                              analytics provider needs fetch/XHR for telemetry
+    //                                              (PR Agent #163 finding — was previously blocked).
     //   frame-ancestors 'self'                       — matches X-Frame-Options: SAMEORIGIN
     //   form-action 'self' base-uri 'self'           — defense in depth
     //   object-src 'none'                            — block Flash/PDF plugins
@@ -47,8 +52,10 @@ const nextConfig = {
     const scriptSrc = [
       "'self'",
       "'unsafe-inline'",
-      "https://*.basemaps.cartocdn.com",
-      "https://unpkg.com",
+      ...(analyticsHost ? [analyticsHost] : []),
+    ].join(" ");
+    const connectSrc = [
+      "'self'",
       ...(analyticsHost ? [analyticsHost] : []),
     ].join(" ");
     const csp = [
@@ -57,7 +64,7 @@ const nextConfig = {
       `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`,
       `img-src 'self' data: blob: https://*.basemaps.cartocdn.com https://unpkg.com`,
       `font-src 'self' data: https://fonts.gstatic.com`,
-      `connect-src 'self'`,
+      `connect-src ${connectSrc}`,
       `frame-ancestors 'self'`,
       `form-action 'self'`,
       `base-uri 'self'`,

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -20,9 +20,52 @@ const nextConfig = {
       { key: "Cross-Origin-Resource-Policy", value: "same-origin" },
       { key: "Cross-Origin-Embedder-Policy", value: "unsafe-none" },
     ];
+    // v1.1.3 security/csp-header: Content-Security-Policy. Build-time computed so the
+    // analytics host is included only when SITE_ANALYTICS_URL is configured.
+    // Directives:
+    //   default-src 'self'                         — baseline
+    //   script-src 'self' 'unsafe-inline' + maps   — Next.js RSC streaming emits inline
+    //                                              __next_f.push() scripts in production;
+    //                                              Leaflet marker icons served from unpkg;
+    //                                              CARTO basemap served from *.basemaps.cartocdn.com.
+    //                                              'unsafe-inline' is unfortunately required by Next.js 16
+    //                                              unless we move to nonce-based CSP (separate pass).
+    //   style-src 'self' 'unsafe-inline' + gfont CSS — Inter from Google Fonts
+    //   img-src 'self' data: blob: + maps tiles      — CARTO + Leaflet
+    //   font-src 'self' data: + gstatic             — Inter font files
+    //   connect-src 'self'                           — all API calls via Next.js rewrites
+    //   frame-ancestors 'self'                       — matches X-Frame-Options: SAMEORIGIN
+    //   form-action 'self' base-uri 'self'           — defense in depth
+    //   object-src 'none'                            — block Flash/PDF plugins
+    const analyticsHost = (() => {
+      try {
+        return process.env.SITE_ANALYTICS_URL ? new URL(process.env.SITE_ANALYTICS_URL).origin : "";
+      } catch {
+        return "";
+      }
+    })();
+    const scriptSrc = [
+      "'self'",
+      "'unsafe-inline'",
+      "https://*.basemaps.cartocdn.com",
+      "https://unpkg.com",
+      ...(analyticsHost ? [analyticsHost] : []),
+    ].join(" ");
+    const csp = [
+      `default-src 'self'`,
+      `script-src ${scriptSrc}`,
+      `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`,
+      `img-src 'self' data: blob: https://*.basemaps.cartocdn.com https://unpkg.com`,
+      `font-src 'self' data: https://fonts.gstatic.com`,
+      `connect-src 'self'`,
+      `frame-ancestors 'self'`,
+      `form-action 'self'`,
+      `base-uri 'self'`,
+      `object-src 'none'`,
+    ].join("; ");
     const cacheNoStore = { key: "Cache-Control", value: "no-store, must-revalidate" };
     return [
-      { source: "/:path*", headers: [...securityHeaders, cacheNoStore] },
+      { source: "/:path*", headers: [...securityHeaders, { key: "Content-Security-Policy", value: csp }, cacheNoStore] },
     ];
   },
   // Proxy /api/* to the backend (ivdrive-api in Docker; use localhost when running frontend on host)


### PR DESCRIPTION
### **User description**
## 📋 Summary

Add CSP via next.config.ts headers() — addresses web-check.xyz Missing CSP finding.

Directives cover all known external resources (Next.js RSC inline scripts via 'unsafe-inline', Leaflet via unpkg, CARTO basemap tiles, Inter via Google Fonts). Build-time computes the analytics host if SITE_ANALYTICS_URL is set.

Verification: npx next build passes; build output routes-manifest.json includes Content-Security-Policy header.
<!-- 🤖 PR Agent will automatically enhance this description with detailed file walkthrough -->
<!-- ⚠️ This section must be filled out (at least 20 characters) for PR validation to pass -->

**Related Issues:** Closes #v1.1.3-remediation-plan P2-C


---

## 🧩 Type of Change

<!-- Mark the relevant option with an 'x' - At least one must be checked for PR validation -->

- [x] 🆕 New feature (e.g. new dashboard, API endpoint)
- [ ] 🐛 Bug fix
- [ ] ⚙️ Backend change (API, collector, database)
- [ ] 🎨 Frontend change (UI, charts, pages)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

<!-- Mark completed items with an 'x' -->

- [ ] Backend runs and tests pass (if applicable)
- [ ] Frontend builds (`npm run build` in `frontend/`)
- [ ] Manual testing done (if applicable)

---

## 👥 Reviewer Notes

<!-- What should reviewers focus on? Any specific questions or areas of uncertainty? -->


---

## 📌 Additional Context

<!-- Any other context, links to documentation, or important notes -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add robust Content-Security-Policy (CSP) header.

- Support external resources like CARTO and Leaflet.

- Dynamically include analytics host from environment variables.

- Apply CSP globally to all application routes.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Config ["next.config.ts"]
    ENV["SITE_ANALYTICS_URL"] -- "Parse Origin" --> CSP_Gen["Generate CSP String"]
    CSP_Gen -- "Add Header" --> Headers["Security Headers"]
  end
  Headers -- "Apply to" --> Routes["/:path*"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Security</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>next.config.ts</strong><dd><code>Add CSP header to Next.js configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/next.config.ts

<ul><li>Calculates the analytics origin from the <code>SITE_ANALYTICS_URL</code> <br>environment variable.<br> <li> Constructs a detailed CSP string covering scripts, styles, images, and <br>fonts from trusted sources.<br> <li> Integrates the <code>Content-Security-Policy</code> header into the global security <br>headers list for all routes.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/163/files#diff-7702f0833633e43f13b4cdfe6f086298da528924380b00f3ad0291071b0bb345">+44/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

