### PR TITLE
fix(collector): retry startup DB query if Postgres is briefly unreachable

### DIFF
--- a/backend/app/services/collector.py
+++ b/backend/app/services/collector.py
@@ -72,14 +72,44 @@ class DataCollector:
 
     async def start(self) -> None:
         registered = 0
-        async with async_session() as session:
-            stmt = (
-                select(UserVehicle)
-                .where(UserVehicle.collection_enabled.is_(True))
-                .options(selectinload(UserVehicle.connector_session))
+        # v1.1.3 fix/collector-startup-retry: wrap the initial DB query in a retry loop.
+        # Previously, if Postgres was briefly unavailable (e.g. just restarted itself),
+        # asyncpg raised ConnectionRefusedError at startup and the entire process exited
+        # with code 1 — leaving the container Up but with 0 processes. We'd then
+        # need a manual restart to recover. Retry up to 12 times × 5s = 60s before
+        # giving up (docker compose restart policy then takes over for the next attempt).
+        vehicles: list = []
+        last_exc: Exception | None = None
+        for attempt in range(1, 13):
+            try:
+                async with async_session() as session:
+                    stmt = (
+                        select(UserVehicle)
+                        .where(UserVehicle.collection_enabled.is_(True))
+                        .options(selectinload(UserVehicle.connector_session))
+                    )
+                    result = await session.execute(stmt)
+                    vehicles = result.scalars().all()
+                if attempt > 1:
+                    logger.info(
+                        "DataCollector: Postgres reachable after %d attempts", attempt,
+                    )
+                break
+            except Exception as exc:
+                last_exc = exc
+                logger.warning(
+                    "DataCollector: startup DB query failed (attempt %d/12): %s — retrying in 5s",
+                    attempt, exc,
+                )
+                await asyncio.sleep(5)
+        else:
+            # Exhausted retries — re-raise so the process exits with a clear traceback
+            # and docker compose restart policy can pick up the next attempt.
+            logger.error(
+                "DataCollector: Postgres unreachable after 12 attempts; exiting for restart policy."
             )
-            result = await session.execute(stmt)
-            vehicles = result.scalars().all()
+            if last_exc:
+                raise last_exc
 
         for vehicle in vehicles:
             if vehicle.connector_session and vehicle.connector_session.access_token_encrypted:


### PR DESCRIPTION
### **User description**
## 📋 Summary

The collector process was exit-looping because start()'s first DB query failed with ConnectionRefusedError whenever Postgres was briefly unavailable (e.g. just restarted). Wrap in 12-attempt / 5s / 60s retry loop. If still failing, re-raise for clean exit so docker compose restart policy takes over (no more 1s thrash). Fixes P0-A observed as 'Restarting (1) 1 second ago' for ~40 minutes on prod today.
<!-- 🤖 PR Agent will automatically enhance this description with detailed file walkthrough -->
<!-- ⚠️ This section must be filled out (at least 20 characters) for PR validation to pass -->

**Related Issues:** Closes #v1.1.3-remediation-plan P0-A


---

## 🧩 Type of Change

<!-- Mark the relevant option with an 'x' - At least one must be checked for PR validation -->

- [ ] 🆕 New feature (e.g. new dashboard, API endpoint)
- [x] 🐛 Bug fix
- [ ] ⚙️ Backend change (API, collector, database)
- [ ] 🎨 Frontend change (UI, charts, pages)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

<!-- Mark completed items with an 'x' -->

- [ ] Backend runs and tests pass (if applicable)
- [ ] Frontend builds (`npm run build` in `frontend/`)
- [ ] Manual testing done (if applicable)

---

## 👥 Reviewer Notes

<!-- What should reviewers focus on? Any specific questions or areas of uncertainty? -->


---

## 📌 Additional Context

<!-- Any other context, links to documentation, or important notes -->


___

### **PR Type**
Bug fix


___

### **Description**
- Implement a retry loop for the initial database query during collector startup.

- Configure 12 retry attempts with 5-second intervals, totaling a 60-second wait period.

- Add logging to track connection attempts and successful recovery after failures.

- Re-raise the last exception after retry exhaustion to allow system restart policies to take over.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph DataCollector
    A["start()"] -- "Initial DB Query" --> B{"Success?"}
    B -- "No (Attempt < 12)" --> C["Wait 5s"]
    C --> A
    B -- "No (Attempt == 12)" --> D["Log Error & Raise Exception"]
    B -- "Yes" --> E["Register Vehicles"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>collector.py</strong><dd><code>Add retry mechanism to startup database connection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/services/collector.py

<ul><li>Wrapped the initial <code>UserVehicle</code> database query in a <code>for</code> loop to handle <br>transient connection issues.<br> <li> Added a 5-second sleep between retry attempts using <code>asyncio.sleep</code>.<br> <li> Included logging for warning about failed attempts and info for <br>successful recovery after a retry.<br> <li> Implemented a final exception re-raise after 12 failed attempts to <br>ensure the process exits for external restart management.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/164/files#diff-8a30690d0e5272fc5019ae6ef3cea8a316de8e9eeaf5c905673836c06982d574">+37/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

