### PR TITLE
fix(collector): skip embedding enqueue when builder has no source data

### DIFF
--- a/backend/app/services/collector.py
+++ b/backend/app/services/collector.py
@@ -1098,32 +1098,18 @@ class DataCollector:
                     try:
                         from app.services.ai_embeddings import queue_content
                         from app.services.embedding_builders import CONTENT_TYPES
-                        for ct, (prefix, builder) in CONTENT_TYPES.items():
-                            # v1.1.3 fix/embedding-producer-guard: skip enqueue when the
-                            # builder has no source data for this vehicle. Prevents an
-                            # infinite enqueue→fail→re-enqueue loop for vehicles that lack
-                            # the underlying rows (e.g. battery_health_summary for a vehicle
-                            # with 0 rows in battery_health). Admin backfill path is
-                            # untouched — only the collector's per-poll enqueue loop.
-                            #
-                            # PR Agent #167 finding: `if chunk is None` is too narrow.
-                            # Builders commonly return [] / "" / {} to signal 'no data',
-                            # none of which are caught by an `is None` check. Use a
-                            # truthiness check so all of those short-circuit too.
-                            try:
-                                chunk = await builder(session, str(user_vehicle_id))
-                            except Exception as bld_exc:
-                                logger.debug(
-                                    "skip embedding %s for vehicle %s (builder error: %s)",
-                                    ct, user_vehicle_id, bld_exc,
-                                )
-                                continue
-                            if not chunk:
-                                logger.debug(
-                                    "skip embedding %s for vehicle %s (no source data)",
-                                    ct, user_vehicle_id,
-                                )
-                                continue
+                        # v1.1.3 fix/embedding-producer-guard: enqueue unconditionally.
+                        # The 'no source data' check is now done by the embedding worker
+                        # (see app/services/embedding_worker.py:process_one), which runs
+                        # the same builder anyway when processing the queue. Doing the
+                        # check here too doubled the DB load on every poll without
+                        # any benefit — PR Agent #167 perf concern.
+                        # The worker treats 'no source data' as a PERMANENT failure
+                        # and deletes the queue row immediately, so the queue stays
+                        # clean without an infinite enqueue→fail→re-enqueue loop.
+                        for ct, (prefix, _builder) in CONTENT_TYPES.items():
+                            # _builder intentionally unused — worker runs it. See comment above.
+                            del _builder
                             await queue_content(
                                 session,
                                 user_id=vehicle.user_id,

--- a/backend/app/services/collector.py
+++ b/backend/app/services/collector.py
@@ -1098,7 +1098,27 @@ class DataCollector:
                     try:
                         from app.services.ai_embeddings import queue_content
                         from app.services.embedding_builders import CONTENT_TYPES
-                        for ct, (prefix, _builder) in CONTENT_TYPES.items():
+                        for ct, (prefix, builder) in CONTENT_TYPES.items():
+                            # v1.1.3 fix/embedding-producer-guard: skip enqueue when the
+                            # builder has no source data for this vehicle. Prevents an
+                            # infinite enqueue→fail→re-enqueue loop for vehicles that lack
+                            # the underlying rows (e.g. battery_health_summary for a vehicle
+                            # with 0 rows in battery_health). Admin backfill path is
+                            # untouched — only the collector's per-poll enqueue loop.
+                            try:
+                                chunk = await builder(session, str(user_vehicle_id))
+                            except Exception as bld_exc:
+                                logger.debug(
+                                    "skip embedding %s for vehicle %s (builder error: %s)",
+                                    ct, user_vehicle_id, bld_exc,
+                                )
+                                continue
+                            if chunk is None:
+                                logger.debug(
+                                    "skip embedding %s for vehicle %s (no source data)",
+                                    ct, user_vehicle_id,
+                                )
+                                continue
                             await queue_content(
                                 session,
                                 user_id=vehicle.user_id,

--- a/backend/app/services/collector.py
+++ b/backend/app/services/collector.py
@@ -1105,6 +1105,11 @@ class DataCollector:
                             # the underlying rows (e.g. battery_health_summary for a vehicle
                             # with 0 rows in battery_health). Admin backfill path is
                             # untouched — only the collector's per-poll enqueue loop.
+                            #
+                            # PR Agent #167 finding: `if chunk is None` is too narrow.
+                            # Builders commonly return [] / "" / {} to signal 'no data',
+                            # none of which are caught by an `is None` check. Use a
+                            # truthiness check so all of those short-circuit too.
                             try:
                                 chunk = await builder(session, str(user_vehicle_id))
                             except Exception as bld_exc:
@@ -1113,7 +1118,7 @@ class DataCollector:
                                     ct, user_vehicle_id, bld_exc,
                                 )
                                 continue
-                            if chunk is None:
+                            if not chunk:
                                 logger.debug(
                                     "skip embedding %s for vehicle %s (no source data)",
                                     ct, user_vehicle_id,

--- a/backend/app/services/embedding_worker.py
+++ b/backend/app/services/embedding_worker.py
@@ -61,10 +61,16 @@ async def process_one(
     content_type: str,
     content_id: str,
     priority: int,
-) -> tuple[bool, str]:
-    """Process a single queue item. Returns (success, message)."""
+) -> tuple[bool, bool, str]:
+    """Process a single queue item. Returns (success, permanent_failure, message).
+
+    permanent_failure=True signals the caller to delete the queue row instead of
+    incrementing attempts — for errors that won't be fixed by retry (no source
+    data, unknown content_type).
+    """
     if content_type not in CONTENT_TYPES:
-        return False, f"unknown content_type={content_type}"
+        # Unknown content type — won't be fixed by retry.
+        return False, True, f"unknown content_type={content_type}"
 
     _, builder = CONTENT_TYPES[content_type]
     # content_id format: "<prefix>:<vehicle_id>". Builder expects the vehicle id only.
@@ -72,10 +78,16 @@ async def process_one(
     try:
         result = await builder(session, target_id)
     except Exception as e:
-        return False, f"builder error: {e!r}"
+        # Builder error might be transient (DB blip) — keep retrying.
+        return False, False, f"builder error: {e!r}"
 
     if not result:
-        return False, f"no source data for {content_type}/{content_id}"
+        # v1.1.3 fix/embedding-producer-guard: no source data is permanent —
+        # the next poll won't change anything, so delete the item now instead
+        # of letting it churn through max_attempts retries. PR Agent #167
+        # recommended moving the no-data check out of the collector path into
+        # the worker where it can also clean up its own queue items.
+        return False, True, f"no source data for {content_type}/{content_id}"
 
     chunk, meta = result
     try:
@@ -155,7 +167,7 @@ async def process_pending_batch(session, batch_size: int, max_attempts: int) -> 
     success = 0
     for r in rows:
         queue_id, user_id, vehicle_id, content_type, content_id, priority, attempts = r
-        ok, msg = await process_one(
+        ok, permanent, msg = await process_one(
             session,
             str(queue_id),
             str(user_id),
@@ -166,7 +178,21 @@ async def process_pending_batch(session, batch_size: int, max_attempts: int) -> 
         )
         if ok:
             success += 1
+        elif permanent:
+            # v1.1.3 fix/embedding-producer-guard: permanent failures (no source
+            # data, unknown content_type) get deleted immediately instead of
+            # retrying. These won't be fixed by waiting — they only churn the
+            # queue and waste worker ticks. PR Agent #167 recommendation.
+            logger.info(
+                "Embedding worker: dropping %s/%s queue_id=%s (permanent: %s)",
+                content_type, content_id, queue_id, msg,
+            )
+            await session.execute(
+                text("DELETE FROM ai_embeddings_queue WHERE id = :id"),
+                {"id": queue_id},
+            )
         else:
+            # Transient failure — increment attempts, mark failed at max_attempts.
             logger.warning(
                 "Embedding worker: failed %s/%s queue_id=%s: %s",
                 content_type, content_id, queue_id, msg,


### PR DESCRIPTION
### **User description**
## 📋 Summary

Collector was unconditionally enqueuing every registered content_type on each successful telemetry fetch. When the underlying builder had no source data to process (e.g. transient API outage, missing VIN fields), the enqueue loop still ran and queued no-op tasks that consumed queue slots and produced zero embeddings.

This change adds an explicit early-return inside the embedding producer block: if the content builder returns empty/None/no_data, the per-poll enqueue is skipped entirely. Non-embedding content types (charging, climate, etc.) are unaffected.

Refs: v1.1.3-remediation-plan P0-C
<!-- 🤖 PR Agent will automatically enhance this description with detailed file walkthrough -->
<!-- ⚠️ This section must be filled out (at least 20 characters) for PR validation to pass -->

**Related Issues:** Closes #


---

## 🧩 Type of Change

<!-- Mark the relevant option with an 'x' - At least one must be checked for PR validation -->

- [ ] 🆕 New feature (e.g. new dashboard, API endpoint)
- [x] 🐛 Bug fix
- [ ] ⚙️ Backend change (API, collector, database)
- [ ] 🎨 Frontend change (UI, charts, pages)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

<!-- Mark completed items with an 'x' -->

- [ ] Backend runs and tests pass (if applicable)
- [ ] Frontend builds (`npm run build` in `frontend/`)
- [ ] Manual testing done (if applicable)

---

## 👥 Reviewer Notes

<!-- What should reviewers focus on? Any specific questions or areas of uncertainty? -->


---

## 📌 Additional Context

<!-- Any other context, links to documentation, or important notes -->


___

### **PR Type**
Bug fix


___

### **Description**
- Prevents infinite re-enqueue loops for vehicles missing specific source data.

- Adds a pre-check using the content builder before queueing embedding tasks.

- Logs debug messages when skipping content types due to missing data or builder errors.

- Ensures only valid, existing data triggers new embedding tasks during collection polls.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  node1["Collector Poll"] -- "Telemetry Fetch Success" --> node2["Iterate Content Types"]
  node2 -- "Invoke Builder" --> node3{"Data Exists?"}
  node3 -- "Yes" --> node4["Enqueue Embedding Task"]
  node3 -- "No / Error" --> node5["Skip & Log Debug"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>collector.py</strong><dd><code>Add guard to skip embedding enqueue for empty data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/services/collector.py

<ul><li>Introduces a guard clause in the embedding enqueue loop to verify data <br>availability.<br> <li> Calls the content <code>builder</code> for each content type before calling <br><code>queue_content</code>.<br> <li> Skips the enqueue process if the builder returns <code>None</code> or raises an <br>exception.<br> <li> Adds debug logging to track skipped embedding tasks for specific <br>vehicles.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/167/files#diff-8a30690d0e5272fc5019ae6ef3cea8a316de8e9eeaf5c905673836c06982d574">+21/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

