### PR TITLE
fix(analytics): clamp derived SoH to [0..100] in fallback live-compute path

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -373,19 +373,27 @@ async def get_battery_health(
             for month in sorted(by_month.keys()):
                 vals = by_month[month]
                 avg_kwh = round(sum(vals) / len(vals), 2)
-                raw_pct = round((avg_kwh / float(factory_kwh)) * 100, 1)
+                # v1.1.3 fix/soh-cap-100-percent: guard against ZeroDivisionError
+                # when factory_kwh is zero/anomalous, and clamp BOTH bounds to [0,100].
+                # PR Agent #168 finding — previous code only clamped the upper bound,
+                # letting negative values from cold-soak under-voltage pass through.
+                f_kwh = float(factory_kwh)
+                raw_pct = round((avg_kwh / f_kwh) * 100, 1) if f_kwh > 0 else 0.0
                 curve_data.append({
                     "month": month,
-                    "estimated_kwh": round(min(avg_kwh, float(factory_kwh)), 2),   # clamp capacity
-                    "soh_pct": min(raw_pct, 100.0),                                  # clamp %
+                    "estimated_kwh": round(max(0.0, min(avg_kwh, f_kwh)), 2),
+                    "soh_pct": max(0.0, min(raw_pct, 100.0)),
                     "sample_count": len(vals),
                 })
 
     if valid:
         raw_latest_kwh = float(valid[0].estimated_kwh)
-        raw_latest_pct = round((raw_latest_kwh / float(factory_kwh)) * 100, 1)
-        latest_derived_kwh = round(min(raw_latest_kwh, float(factory_kwh)), 2)   # clamp capacity
-        latest_derived = min(raw_latest_pct, 100.0)                              # clamp %
+        # v1.1.3 fix/soh-cap-100-percent: same clamp + zero-division guard as above
+        # for the summary latest_derived values.
+        f_kwh = float(factory_kwh)
+        raw_latest_pct = round((raw_latest_kwh / f_kwh) * 100, 1) if f_kwh > 0 else 0.0
+        latest_derived_kwh = round(max(0.0, min(raw_latest_kwh, f_kwh)), 2)
+        latest_derived = max(0.0, min(raw_latest_pct, 100.0))
 
     return {
         "skoda_soh_pct": latest_bh.hv_battery_soh if latest_bh else None,

--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -359,6 +359,9 @@ async def get_battery_health(
     latest_derived_kwh = None
 
     if soh_estimates:
+        # v1.1.3 fix/soh-cap-100-percent: the 103% noise buffer was kept for filtering
+        # (rejects regen-inflated values that exceed 103% of factory), but the resulting
+        # percentage and capacity now clamp to factory. A real battery never has SoH > 100%.
         limit_kwh = float(factory_kwh) * 1.03
         valid = [r for r in soh_estimates if r.estimated_kwh and float(r.estimated_kwh) <= limit_kwh]
         if valid:
@@ -370,17 +373,19 @@ async def get_battery_health(
             for month in sorted(by_month.keys()):
                 vals = by_month[month]
                 avg_kwh = round(sum(vals) / len(vals), 2)
-                soh_pct = round((avg_kwh / float(factory_kwh)) * 100, 1)
+                raw_pct = round((avg_kwh / float(factory_kwh)) * 100, 1)
                 curve_data.append({
                     "month": month,
-                    "estimated_kwh": avg_kwh,
-                    "soh_pct": soh_pct,
+                    "estimated_kwh": round(min(avg_kwh, float(factory_kwh)), 2),   # clamp capacity
+                    "soh_pct": min(raw_pct, 100.0),                                  # clamp %
                     "sample_count": len(vals),
                 })
 
     if valid:
-        latest_derived = round((float(valid[0].estimated_kwh) / float(factory_kwh)) * 100, 1)
-        latest_derived_kwh = float(valid[0].estimated_kwh)
+        raw_latest_kwh = float(valid[0].estimated_kwh)
+        raw_latest_pct = round((raw_latest_kwh / float(factory_kwh)) * 100, 1)
+        latest_derived_kwh = round(min(raw_latest_kwh, float(factory_kwh)), 2)   # clamp capacity
+        latest_derived = min(raw_latest_pct, 100.0)                              # clamp %
 
     return {
         "skoda_soh_pct": latest_bh.hv_battery_soh if latest_bh else None,


### PR DESCRIPTION
### **User description**
## 📋 Summary

QA on 2026-05-24 found ALL 13 vehicles reporting SoH = 95% exactly — statistically impossible. Root cause: the fallback SoH path (used when battery_soh_estimates has no rows) filtered out estimates >103% as 'regen-inflated noise' but accepted anything below 103% verbatim, including negative values from cold-soak under-voltage and values >100% from regen drift.

Fix clamps the final reported SoH to [0, 100] before returning. The full unfiltered estimate still goes into the audit log so we don't lose diagnostic information.

Refs: v1.1.3-remediation-plan P1-A, QA-01 from 2026-05-24
<!-- 🤖 PR Agent will automatically enhance this description with detailed file walkthrough -->
<!-- ⚠️ This section must be filled out (at least 20 characters) for PR validation to pass -->

**Related Issues:** Closes #


---

## 🧩 Type of Change

<!-- Mark the relevant option with an 'x' - At least one must be checked for PR validation -->

- [ ] 🆕 New feature (e.g. new dashboard, API endpoint)
- [x] 🐛 Bug fix
- [ ] ⚙️ Backend change (API, collector, database)
- [ ] 🎨 Frontend change (UI, charts, pages)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

<!-- Mark completed items with an 'x' -->

- [ ] Backend runs and tests pass (if applicable)
- [ ] Frontend builds (`npm run build` in `frontend/`)
- [ ] Manual testing done (if applicable)

---

## 👥 Reviewer Notes

<!-- What should reviewers focus on? Any specific questions or areas of uncertainty? -->


---

## 📌 Additional Context

<!-- Any other context, links to documentation, or important notes -->


___

### **PR Type**
Bug fix


___

### **Description**
- Clamp derived SoH percentage to 100.0.

- Cap estimated capacity at factory kWh.

- Apply clamping to monthly and latest metrics.

- Retain 103% noise filter for input data.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Raw Estimates"] -- "Filter > 103% noise" --> B["Valid Estimates"]
  B -- "Calculate Avg/Latest" --> C["Raw Metrics"]
  C -- "Clamp to 100% / Factory kWh" --> D["Final Analytics Output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.py</strong><dd><code>Clamp battery health metrics to factory limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/api/v1/analytics.py

<ul><li>Introduced <code>min()</code> clamping for <code>soh_pct</code> to ensure it does not exceed <br>100.0 in the analytics output.<br> <li> Capped <code>estimated_kwh</code> at the <code>factory_kwh</code> value for both monthly curve <br>data and the latest derived results.<br> <li> Refactored calculation logic to separate raw computed values from the <br>final clamped output values.<br> <li> Added comments explaining the logic for keeping the 103% noise buffer <br>while clamping the final display values.</ul>


</details>


  </td>
  <td><a href="https://github.com/m7xlab/ivdrive/pull/168/files#diff-1bcd451e46734de2d8e97d41344307998190a3de95c7b5d405ec226041d1cfb3">+10/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

