### PR TITLE
feat(maps): wire CARTO Basemaps API key through all map components

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,5 +86,14 @@ S3_SECRET_KEY=CHANGE_ME
 SITE_ANALYTICS_URL=
 SITE_ANALYTICS_KEY=
 
+# ─── CARTO Basemaps API key (frontend, client-side) ────────
+# Required by CARTO Basemaps public tile service. Get a free key at
+# https://carto.com/basemaps/apikey/ — no approval queue, no CARTO account.
+# The NEXT_PUBLIC_ prefix is required by Next.js so the value is inlined into
+# the browser bundle (maps render client-side). Without this key, the
+# basemaps.cartocdn.com tiles will return a 401 and the "API key required"
+# watermark will appear on every map in the app.
+NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY=CHANGE_ME
+
 # ─── IVDRIVE_VERSION ──────────────────────────────────────────
 IVDRIVE_VERSION=v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **CARTO Basemaps API key wiring**: CARTO now requires an API key for public basemap tile access. New env var `NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY` (added to `.env`, `.env.example`, and `docker-compose.yml` `ivdrive-web` service) is appended as `?key=...` on every `basemaps.cartocdn.com` tile URL across all four map locations: `frontend/src/components/map.tsx` (Car Overview), `frontend/src/components/statistics/MovementDashboard.tsx`, `TripsDashboard.tsx`, and `VisitedDashboard.tsx`. The `NEXT_PUBLIC_` prefix is required by Next.js so the value reaches the client bundle (all four map components render client-side). Get a free key at https://carto.com/basemaps/apikey/ — no approval queue, no CARTO account required. The CSP `img-src` directive already permits `https://*.basemaps.cartocdn.com` (added in v1.1.2.1 PR #163), so no CSP change was needed. Without this key, tiles 401 and the CARTO "API key required" watermark shows on every map.
+
 ## [v1.1.3] - 2026-07-08
 Major authentication architecture overhaul and frontend fetching modernization. Resolves persistent API anti-bot rejection issues and transient backend server errors. The authentication state machine has been hardened to securely maintain and refresh sessions, supported by a newly introduced frontend query layer and user-facing connection state UI.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,12 @@ services:
     image: ivdrive-ivdrive-web:latest
     build:
       context: ./frontend
+      args:
+        # NEXT_PUBLIC_* vars are inlined by `next build` at build time and must
+        # be declared here so the value is available during the builder stage in
+        # frontend/Dockerfile. Mirrored under `environment:` below for any
+        # server-side reads in the running container.
+        NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY: "${NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY:-}"
     environment:
       NEXT_PUBLIC_API_URL: "${NEXT_PUBLIC_API_URL:-}"
       NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY: "${NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY:-}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
         # be declared here so the value is available during the builder stage in
         # frontend/Dockerfile. Mirrored under `environment:` below for any
         # server-side reads in the running container.
+        NEXT_PUBLIC_API_URL: "${NEXT_PUBLIC_API_URL:-}"
         NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY: "${NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY:-}"
     environment:
       NEXT_PUBLIC_API_URL: "${NEXT_PUBLIC_API_URL:-}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       context: ./frontend
     environment:
       NEXT_PUBLIC_API_URL: "${NEXT_PUBLIC_API_URL:-}"
+      NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY: "${NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY:-}"
       SITE_ANALYTICS_URL: "${SITE_ANALYTICS_URL:-}"
       SITE_ANALYTICS_KEY: "${SITE_ANALYTICS_KEY:-}"
     networks:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,12 @@ COPY package.json package-lock.json* ./
 RUN npm install --legacy-peer-deps
 
 FROM base AS builder
+# NEXT_PUBLIC_* env vars must be inlined by `next build` at build time, not
+# runtime. Declared as ARG here and exported as ENV so `next build` sees them;
+# the same names must also be passed via `build.args` in docker-compose.yml
+# for the ivdrive-web service (or via `--build-arg` on `docker build`).
+ARG NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY
+ENV NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY=$NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,7 +12,9 @@ FROM base AS builder
 # runtime. Declared as ARG here and exported as ENV so `next build` sees them;
 # the same names must also be passed via `build.args` in docker-compose.yml
 # for the ivdrive-web service (or via `--build-arg` on `docker build`).
+ARG NEXT_PUBLIC_API_URL
 ARG NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY=$NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules

--- a/frontend/src/components/map.tsx
+++ b/frontend/src/components/map.tsx
@@ -32,11 +32,6 @@ export default function LocationMap({ latitude, longitude }: MapProps) {
 
   const isDark = resolvedTheme === "dark";
 
-  // CARTO Basemaps tiles — require an API key since CARTO gated the public
-  // tile service. NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY is inlined into the client
-  // bundle at build time by Next.js. Get a free key at
-  // https://carto.com/basemaps/apikey/. The CSP img-src directive already
-  // permits https://*.basemaps.cartocdn.com (added in v1.1.2.1 PR #163).
   // CARTO Basemaps tile URL + API key wiring lives in getCartoTileUrl()
   // (frontend/src/lib/map-utils.ts) so all four map components stay in sync.
   const tileUrl = getCartoTileUrl(isDark);

--- a/frontend/src/components/map.tsx
+++ b/frontend/src/components/map.tsx
@@ -5,6 +5,7 @@ import { MapContainer, TileLayer, Marker, ZoomControl } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
 import { useTheme } from "next-themes";
+import { getCartoTileUrl } from "@/lib/map-utils";
 
 // Fix for default Leaflet markers in Next.js/Webpack
 delete (L.Icon.Default.prototype as any)._getIconUrl;
@@ -36,11 +37,9 @@ export default function LocationMap({ latitude, longitude }: MapProps) {
   // bundle at build time by Next.js. Get a free key at
   // https://carto.com/basemaps/apikey/. The CSP img-src directive already
   // permits https://*.basemaps.cartocdn.com (added in v1.1.2.1 PR #163).
-  const cartoKey = process.env.NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY;
-  const keySuffix = cartoKey ? `?key=${cartoKey}` : "";
-  const tileUrl = isDark
-    ? `https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png${keySuffix}`
-    : `https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png${keySuffix}`;
+  // CARTO Basemaps tile URL + API key wiring lives in getCartoTileUrl()
+  // (frontend/src/lib/map-utils.ts) so all four map components stay in sync.
+  const tileUrl = getCartoTileUrl(isDark);
 
   return (
     <div className="absolute inset-0 w-full h-full z-0 bg-[var(--iv-charcoal)]">

--- a/frontend/src/components/map.tsx
+++ b/frontend/src/components/map.tsx
@@ -31,11 +31,16 @@ export default function LocationMap({ latitude, longitude }: MapProps) {
 
   const isDark = resolvedTheme === "dark";
 
-  // CartoDB tiles are free to use without API keys and look very modern, 
-  // similar to Mapbox or stylized maps.
+  // CARTO Basemaps tiles — require an API key since CARTO gated the public
+  // tile service. NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY is inlined into the client
+  // bundle at build time by Next.js. Get a free key at
+  // https://carto.com/basemaps/apikey/. The CSP img-src directive already
+  // permits https://*.basemaps.cartocdn.com (added in v1.1.2.1 PR #163).
+  const cartoKey = process.env.NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY;
+  const keySuffix = cartoKey ? `?key=${cartoKey}` : "";
   const tileUrl = isDark
-    ? "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
-    : "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png";
+    ? `https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png${keySuffix}`
+    : `https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png${keySuffix}`;
 
   return (
     <div className="absolute inset-0 w-full h-full z-0 bg-[var(--iv-charcoal)]">

--- a/frontend/src/components/statistics/MovementDashboard.tsx
+++ b/frontend/src/components/statistics/MovementDashboard.tsx
@@ -409,10 +409,13 @@ function MovementMap({ locations, stayEvents }: { locations: VisitedLocation[]; 
   const center: [number, number] = [latSum / locations.length, lonSum / locations.length];
   const maxMs = Math.max(...stayEvents.map((s) => s.durationMs), 1);
 
-  // Tile URLs matching app theme
+  // Tile URLs matching app theme. CARTO Basemaps require an API key —
+  // NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY is inlined at build time.
+  const cartoKey = process.env.NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY;
+  const keySuffix = cartoKey ? `?key=${cartoKey}` : "";
   const tileUrl = isDark
-    ? "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
-    : "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png";
+    ? `https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png${keySuffix}`
+    : `https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png${keySuffix}`;
 
   return (
     <div className="glass rounded-xl overflow-hidden">

--- a/frontend/src/components/statistics/MovementDashboard.tsx
+++ b/frontend/src/components/statistics/MovementDashboard.tsx
@@ -410,8 +410,6 @@ function MovementMap({ locations, stayEvents }: { locations: VisitedLocation[]; 
   const center: [number, number] = [latSum / locations.length, lonSum / locations.length];
   const maxMs = Math.max(...stayEvents.map((s) => s.durationMs), 1);
 
-  // Tile URLs matching app theme. CARTO Basemaps require an API key —
-  // NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY is inlined at build time.
   // Tile URLs matching app theme. CARTO Basemaps API key wiring lives in
   // getCartoTileUrl() (frontend/src/lib/map-utils.ts).
   const tileUrl = getCartoTileUrl(isDark);

--- a/frontend/src/components/statistics/MovementDashboard.tsx
+++ b/frontend/src/components/statistics/MovementDashboard.tsx
@@ -6,6 +6,7 @@ import "leaflet/dist/leaflet.css";
 import { api } from "@/lib/api";
 import { useTheme } from "next-themes";
 import { formatSmartDuration } from "@/lib/format";
+import { getCartoTileUrl } from "@/lib/map-utils";
 import type { TimelineRange } from "./StatisticsShell";
 
 export interface MovementDashboardProps {
@@ -411,11 +412,9 @@ function MovementMap({ locations, stayEvents }: { locations: VisitedLocation[]; 
 
   // Tile URLs matching app theme. CARTO Basemaps require an API key —
   // NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY is inlined at build time.
-  const cartoKey = process.env.NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY;
-  const keySuffix = cartoKey ? `?key=${cartoKey}` : "";
-  const tileUrl = isDark
-    ? `https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png${keySuffix}`
-    : `https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png${keySuffix}`;
+  // Tile URLs matching app theme. CARTO Basemaps API key wiring lives in
+  // getCartoTileUrl() (frontend/src/lib/map-utils.ts).
+  const tileUrl = getCartoTileUrl(isDark);
 
   return (
     <div className="glass rounded-xl overflow-hidden">

--- a/frontend/src/components/statistics/TripsDashboard.tsx
+++ b/frontend/src/components/statistics/TripsDashboard.tsx
@@ -219,8 +219,6 @@ export function TripsDashboard({ vehicleId, dateRange, summarySubtitle }: TripsD
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
 
-  // CARTO Basemaps require an API key — NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY
-  // is inlined into the client bundle at build time by Next.js.
   // CARTO Basemaps tile URL + API key wiring lives in getCartoTileUrl()
   // (frontend/src/lib/map-utils.ts).
   const tripsTileUrl = getCartoTileUrl(isDark);

--- a/frontend/src/components/statistics/TripsDashboard.tsx
+++ b/frontend/src/components/statistics/TripsDashboard.tsx
@@ -15,6 +15,7 @@ import { api } from "@/lib/api";
 import { MapContainer, TileLayer, Polyline, useMap } from 'react-leaflet';
 import { useTheme } from "next-themes";
 import { TripElevationCard } from "./TripElevationCard";
+import { getCartoTileUrl } from "@/lib/map-utils";
 
 import "leaflet/dist/leaflet.css";
 
@@ -220,10 +221,9 @@ export function TripsDashboard({ vehicleId, dateRange, summarySubtitle }: TripsD
 
   // CARTO Basemaps require an API key — NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY
   // is inlined into the client bundle at build time by Next.js.
-  const cartoKey = process.env.NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY;
-  const tripsTileUrl = isDark
-    ? `https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png${cartoKey ? `?key=${cartoKey}` : ""}`
-    : `https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png${cartoKey ? `?key=${cartoKey}` : ""}`;
+  // CARTO Basemaps tile URL + API key wiring lives in getCartoTileUrl()
+  // (frontend/src/lib/map-utils.ts).
+  const tripsTileUrl = getCartoTileUrl(isDark);
 
 
 

--- a/frontend/src/components/statistics/TripsDashboard.tsx
+++ b/frontend/src/components/statistics/TripsDashboard.tsx
@@ -218,6 +218,13 @@ export function TripsDashboard({ vehicleId, dateRange, summarySubtitle }: TripsD
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
 
+  // CARTO Basemaps require an API key — NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY
+  // is inlined into the client bundle at build time by Next.js.
+  const cartoKey = process.env.NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY;
+  const tripsTileUrl = isDark
+    ? `https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png${cartoKey ? `?key=${cartoKey}` : ""}`
+    : `https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png${cartoKey ? `?key=${cartoKey}` : ""}`;
+
 
 
   // Geocoding helper
@@ -649,7 +656,7 @@ export function TripsDashboard({ vehicleId, dateRange, summarySubtitle }: TripsD
               <TileLayer
 
                 attribution='&copy; <a href="https://carto.com/attributions">CARTO</a>'
-                url={isDark ? "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png" : "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"}
+                url={tripsTileUrl}
               />
 
               {displayTrips.map(trip => {

--- a/frontend/src/components/statistics/VisitedDashboard.tsx
+++ b/frontend/src/components/statistics/VisitedDashboard.tsx
@@ -143,8 +143,6 @@ function VisitedMap({ locations }: VisitedMapProps) {
     lonSum / locations.length,
   ];
 
-  // CARTO Basemaps require an API key — NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY
-  // is inlined into the client bundle at build time by Next.js.
   // CARTO Basemaps tile URL + API key wiring lives in getCartoTileUrl()
   // (frontend/src/lib/map-utils.ts).
   const tileUrl = getCartoTileUrl(isDark);

--- a/frontend/src/components/statistics/VisitedDashboard.tsx
+++ b/frontend/src/components/statistics/VisitedDashboard.tsx
@@ -5,6 +5,7 @@ import { MapPin, Loader2, Zap } from "lucide-react";
 import "leaflet/dist/leaflet.css";
 import { api } from "@/lib/api";
 import { useTheme } from "next-themes";
+import { getCartoTileUrl } from "@/lib/map-utils";
 import type { TimelineRange } from "./StatisticsShell";
 
 export interface VisitedDashboardProps {
@@ -144,11 +145,9 @@ function VisitedMap({ locations }: VisitedMapProps) {
 
   // CARTO Basemaps require an API key — NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY
   // is inlined into the client bundle at build time by Next.js.
-  const cartoKey = process.env.NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY;
-  const keySuffix = cartoKey ? `?key=${cartoKey}` : "";
-  const tileUrl = isDark
-    ? `https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png${keySuffix}`
-    : `https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png${keySuffix}`;
+  // CARTO Basemaps tile URL + API key wiring lives in getCartoTileUrl()
+  // (frontend/src/lib/map-utils.ts).
+  const tileUrl = getCartoTileUrl(isDark);
 
   return (
     <div className="absolute inset-0 z-0">

--- a/frontend/src/components/statistics/VisitedDashboard.tsx
+++ b/frontend/src/components/statistics/VisitedDashboard.tsx
@@ -142,8 +142,13 @@ function VisitedMap({ locations }: VisitedMapProps) {
     lonSum / locations.length,
   ];
 
-  const tileUrl =
-    isDark ? "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png" : "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png";
+  // CARTO Basemaps require an API key — NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY
+  // is inlined into the client bundle at build time by Next.js.
+  const cartoKey = process.env.NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY;
+  const keySuffix = cartoKey ? `?key=${cartoKey}` : "";
+  const tileUrl = isDark
+    ? `https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png${keySuffix}`
+    : `https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png${keySuffix}`;
 
   return (
     <div className="absolute inset-0 z-0">

--- a/frontend/src/lib/map-utils.ts
+++ b/frontend/src/lib/map-utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Centralized CARTO Basemaps tile URL builder.
+ *
+ * CARTO Basemaps now require an API key for public tile access (CARTO gated
+ * the public service). Without a key, every tile returns 401 and the "API
+ * key required" watermark shows on every map in the app.
+ *
+ * Get a free key at https://carto.com/basemaps/apikey/ — no approval queue,
+ * no CARTO account required.
+ *
+ * The `NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY` env var is inlined into the client
+ * bundle at build time by Next.js, so it must also be passed via `build.args`
+ * in docker-compose.yml + `ARG`/`ENV` in the frontend Dockerfile builder
+ * stage. See PR #181 for the full build-args wiring.
+ *
+ * Returns a tile URL suitable for Leaflet `TileLayer.url`.
+ *
+ * @param isDark - whether to use the dark theme variant
+ * @returns the tile URL with optional `?key=***` query param appended
+ */
+export function getCartoTileUrl(isDark: boolean): string {
+  const key = process.env.NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY;
+  const theme = isDark ? "dark_all" : "light_all";
+  const keySuffix = key ? `?key=***}` : "";
+  return `https://{s}.basemaps.cartocdn.com/${theme}/{z}/{x}/{y}{r}.png${keySuffix}`;
+}


### PR DESCRIPTION
## 📋 Summary

CARTO Basemaps now requires an API key for public tile access. Without a key, every tile returns 401 and the "API key required" watermark shows on every map in the app.

This PR adds the new `NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY` env var and wires it through the build pipeline so `next build` can actually inline it into the client bundle:

- `.env.example` — placeholder + comment
- `docker-compose.yml` — added to `ivdrive-web` `environment:` AND `build.args` for **both** `NEXT_PUBLIC_API_URL` AND `NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY` (PR Agent Medium-importance suggestion, fully addressed)
- `frontend/Dockerfile` — `ARG` + `ENV` in the `builder` stage for both vars so `next build` sees them
- `frontend/src/lib/map-utils.ts` — **new** `getCartoTileUrl(isDark)` helper (PR Agent Low-importance suggestion, addressed)
- All four map components — now use `getCartoTileUrl(isDark)` instead of duplicating the tile-URL construction inline

The `NEXT_PUBLIC_` prefix is mandatory: all four map components have `"use client"` at the top, and Next.js strips non-prefixed vars from the client bundle. Build-time inlining requires the value to be present during `docker build`'s `next build` step, hence the `build.args` + `ARG`/`ENV` wiring. Without it, both `process.env.NEXT_PUBLIC_API_URL` (used in `frontend/src/lib/api/core.ts` to construct the API base URL for fetch calls) and `process.env.NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY` would be `undefined` in the client bundle and the app would silently break in production.

**Related Issues:** Closes #

---

## 🧩 Type of Change

- [x] 🆕 New feature (new env var, tile URL pattern, build-args wiring)
- [x] 🎨 Frontend change (4 map components updated, new `lib/map-utils.ts` helper)
- [x] 🔧 Configuration / deployment (`.env.example`, `docker-compose.yml`, `frontend/Dockerfile`)
- [x] 📚 Documentation update (`CHANGELOG.md`)

---

## ✅ Validation

- [x] Frontend builds (`tsc --noEmit` in `frontend/` — no new errors introduced on the touched files. The 6 pre-existing baseline errors in `BatterySoHDashboard`, `CarOverviewDashboard`, `SpeedTempMatrixDashboard`, `TripsDashboard` from v1.1.2.1 — including `TripsDashboard.tsx(688,23)` Polyline JSX — are all suppressed by `ignoreBuildErrors: true` in `next.config.ts`)
- [ ] Backend runs and tests pass (no backend changes — N/A)
- [ ] Manual testing done (left to reviewer — see Reviewer Notes)

---

## 👥 Reviewer Notes

- **Get a free key** at https://carto.com/basemaps/apikey/ — no approval queue, no CARTO account required
- **Test setup**: set `NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY` in `.env`, then `docker compose up -d --build ivdrive-web` so both `NEXT_PUBLIC_*` vars are inlined into the static bundle
- **Verify**: open any map page (Car Overview / Trips / Movement / Visited Locations) and inspect a tile request — URL should end with `?key=***`. Also check the Network tab for `/api/...` requests — they should hit the URL in `NEXT_PUBLIC_API_URL` (default empty → same-origin via Next.js rewrites)
- **Rotating either key requires a web rebuild** — both values are baked into the static bundle, not read at runtime
- **PR Agent suggestions status**:
  - ✅ **Medium (importance 8)** — build args for `NEXT_PUBLIC_*` — fully addressed across `c40e641` + `4870632`
  - ✅ **Low (importance 6)** — centralize tile URL logic into `frontend/src/lib/map-utils.ts` — addressed in `f023196` (helper + 4 file updates)

---

## 📌 Additional Context

- **CSP unchanged**: `img-src` already permits `https://*.basemaps.cartocdn.com` (added in v1.1.2.1 PR #163)
- **No new dependencies, no migrations, no backend changes**
- **4 commits on this branch**:
  - `de1e7cb` — feat(maps): wire CARTO Basemaps API key through all map components
  - `c40e641` — fix(deploy): pass NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY as build arg
  - `4870632` — fix(deploy): complete build-args wiring for NEXT_PUBLIC_API_URL
  - `f023196` — refactor(map): centralize CARTO tile URL logic into shared utility
- **Follow-up PR planned** (separate): admin invites list pagination + bulk cleanup endpoint (`POST /admin/invites/cleanup?older_than_days=30`, skip-pending, 30-day default)
- **`.env`** (local-only, gitignored) had the var renamed from `CARTO_BASEMAPS_API_KEY` → `NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY` to follow Next.js client-side env conventions