### PR TITLE
fix(web): same-origin Hub image for v1.1.14 production login

### DIFF
--- a/.github/workflows/build-multi-arch-images.yml
+++ b/.github/workflows/build-multi-arch-images.yml
@@ -1,6 +1,9 @@
 # Build iVDrive Docker images for linux/amd64 and linux/arm64, push to Docker Hub.
-# Runs only when a new tag (and release) is pushed. Requires secrets: DOCKERHUB_ACCESS_KEY
-# (and DOCKERHUB_USERNAME if not m7xlab). Images: m7xlab/ivdrive-api, m7xlab/ivdrive-collector, m7xlab/ivdrive-web
+# Runs when a v* tag is pushed (api + collector + web, also retags :latest).
+# workflow_dispatch can rebuild a tag; default is web-only so a login/CSP hotfix
+# cannot overwrite production api/collector. Requires secrets: DOCKERHUB_ACCESS_KEY
+# and NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY (inlined into the web bundle). Never bake
+# NEXT_PUBLIC_API_URL to http://localhost:8000 — production CSP is connect-src 'self'.
 
 name: Build multi-arch images
 
@@ -9,6 +12,22 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Registry tag to push (v1.1.14 or latest)
+        required: false
+        default: latest
+      services:
+        description: Images to rebuild
+        type: choice
+        options:
+          - web
+          - all
+        default: web
+      update_latest:
+        description: Also retag :latest
+        type: boolean
+        default: false
 
 env:
   COMPOSE_PROJECT_NAME: ivdrive
@@ -21,11 +40,25 @@ jobs:
     steps:
       - name: Set image tag
         id: meta
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RAW_TAG: ${{ github.event.inputs.image_tag }}
+          UPDATE_LATEST: ${{ github.event.inputs.update_latest }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="${RAW_TAG:-latest}"
           else
-            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          case "$TAG" in
+            latest|v[0-9]*) ;;
+            *) echo "Refusing image tag: $TAG" >&2; exit 1 ;;
+          esac
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" != "workflow_dispatch" ] || [ "$TAG" = "latest" ] || [ "$UPDATE_LATEST" = "true" ]; then
+            echo "push_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "push_latest=false" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/checkout@v4
@@ -40,6 +73,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ACCESS_KEY }}
 
       - name: Build and push API image
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.services == 'all'
         uses: docker/build-push-action@v6
         with:
           context: ./backend
@@ -49,9 +83,10 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/ivdrive-api:${{ steps.meta.outputs.tag }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/ivdrive-api:latest
+            ${{ steps.meta.outputs.push_latest == 'true' && format('{0}/{1}/ivdrive-api:latest', env.REGISTRY, env.IMAGE_NAMESPACE) || format('{0}/{1}/ivdrive-api:{2}', env.REGISTRY, env.IMAGE_NAMESPACE, steps.meta.outputs.tag) }}
 
       - name: Build and push Collector image
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.services == 'all'
         uses: docker/build-push-action@v6
         with:
           context: ./backend
@@ -61,8 +96,21 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/ivdrive-collector:${{ steps.meta.outputs.tag }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/ivdrive-collector:latest
+            ${{ steps.meta.outputs.push_latest == 'true' && format('{0}/{1}/ivdrive-collector:latest', env.REGISTRY, env.IMAGE_NAMESPACE) || format('{0}/{1}/ivdrive-collector:{2}', env.REGISTRY, env.IMAGE_NAMESPACE, steps.meta.outputs.tag) }}
 
+      - name: Require CARTO basemap key
+        env:
+          CARTO_KEY: ${{ secrets.NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY }}
+        run: |
+          if [ -z "$CARTO_KEY" ]; then
+            echo "Set repo secret NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY before building the web image." >&2
+            exit 1
+          fi
+
+      # NEXT_PUBLIC_* is inlined by `next build`. Leave NEXT_PUBLIC_API_URL empty so
+      # the browser uses same-origin `/api/*` (Next rewrites to ivdrive-api). Baking
+      # http://localhost:8000 makes production login hit the visitor's machine and
+      # CSP connect-src 'self' blocks it. CARTO key is client-side by design.
       - name: Build and push Web image
         uses: docker/build-push-action@v6
         with:
@@ -71,7 +119,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
-            NEXT_PUBLIC_API_URL=http://localhost:8000
+            NEXT_PUBLIC_API_URL=
+            NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY=${{ secrets.NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/ivdrive-web:${{ steps.meta.outputs.tag }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/ivdrive-web:latest
+            ${{ steps.meta.outputs.push_latest == 'true' && format('{0}/{1}/ivdrive-web:latest', env.REGISTRY, env.IMAGE_NAMESPACE) || format('{0}/{1}/ivdrive-web:{2}', env.REGISTRY, env.IMAGE_NAMESPACE, steps.meta.outputs.tag) }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Major feature release on top of v1.1.3: six-method Battery SoH v2 (weighted-medi
 - **Invite registration UX** (PR #182): register page accepts a pasted invite token (or a full invite URL); invite emails include the raw token as well as the button link.
 
 ### Fixed
+- **Hub `ivdrive-web` login CSP**: the multi-arch workflow baked `NEXT_PUBLIC_API_URL=http://localhost:8000` into the browser bundle, so production login hit the visitor’s machine and was blocked by `connect-src 'self'`. Hub `m7xlab/ivdrive-web:v1.1.14` is rebuilt with an empty URL (same-origin `/api` via Next rewrites). **CARTO tile key**: `getCartoTileUrl` appended a literal `?key=***}` instead of the env value — maps 401’d even when the key was baked.
 - **Charging taper SoH sign** (PR #182): DC power drop (`(recent − earlier) / earlier`) was negated into a SoH **increase**. Power drop now lowers SoH (clamped ±5 points). Cached combined rows still include the old sign until recompute.
 - **Geo inflight hang on cancel** (PR #182): `CancelledError` is `BaseException`, not `Exception`. If the leader reverse-geocode request is cancelled, waiters on the same lat/lon Future are now resolved in `finally`.
 - **SoH method cache mix** (PR #182): per-method breakdown is loaded with the combined row’s `computed_at` so a partial older persist cannot mix into the dashboard.

--- a/frontend/src/lib/map-utils.ts
+++ b/frontend/src/lib/map-utils.ts
@@ -16,11 +16,11 @@
  * Returns a tile URL suitable for Leaflet `TileLayer.url`.
  *
  * @param isDark - whether to use the dark theme variant
- * @returns the tile URL with optional `?key=***` query param appended
+ * @returns the tile URL with optional `?key=` query param appended
  */
 export function getCartoTileUrl(isDark: boolean): string {
   const key = process.env.NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY;
   const theme = isDark ? "dark_all" : "light_all";
-  const keySuffix = key ? `?key=***}` : "";
+  const keySuffix = key ? `?key=${key}` : "";
   return `https://{s}.basemaps.cartocdn.com/${theme}/{z}/{x}/{y}{r}.png${keySuffix}`;
 }


### PR DESCRIPTION
## 📋 Summary

Hub `ivdrive-web:v1.1.14` baked `NEXT_PUBLIC_API_URL=http://localhost:8000` into the Next.js bundle. Production CSP is `connect-src 'self'`, so login on ivdrive.eu was blocked. This PR leaves that build-arg empty (same-origin `/api` via Next rewrites), requires the CARTO key secret for Hub web builds, and defaults workflow_dispatch to **web only** so a rebuild cannot overwrite production api/collector.

Also fixes `getCartoTileUrl`: it appended a literal `?key=***}` instead of the env value, so map tiles 401’d even when the key was baked.

**Related Issues:** none to close. Production NAS is already running the rebuilt Hub web image; this PR lands the source so the next tag build does not repeat the localhost bake.

---

## 🧩 Type of Change

- [ ] 🆕 New feature (e.g. new dashboard, API endpoint)
- [x] 🐛 Bug fix
- [ ] ⚙️ Backend change (API, collector, database)
- [x] 🎨 Frontend change (UI, charts, pages)
- [x] 📚 Documentation update
- [x] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

- [ ] Backend runs and tests pass (if applicable)
- [x] Frontend builds (`npm run build` in `frontend/`)
  - Local `docker compose build --no-cache ivdrive-web`; Hub `m7xlab/ivdrive-web:v1.1.14` pushed (linux/amd64) and pulled on production
- [x] Manual testing done (if applicable)
  - Production login: no `localhost:8000` in the bundle; `/` and `/login` return 200
  - Bundle uses same-origin `/api/v1/auth/login`

---

## 👥 Reviewer Notes

Approve/merge so `main` matches the production web image. Do **not** retag or rebuild api/collector.

1. **Do not dispatch the old workflow on `main`** until this is merged. The current `main` workflow still bakes `http://localhost:8000` and rebuilds all three images plus `:latest`.
2. After merge, optional: Actions → Build multi-arch images → `image_tag=v1.1.14`, `services=web`, `update_latest` as you prefer. That restores amd64+arm64 on Hub. Production NAS is amd64 and already works.
3. Repo secret `NEXT_PUBLIC_CARTO_BASEMAPS_API_KEY` must stay set; the web job fails closed without it.
4. Git tag `v1.1.14` can stay on `abeeecd`. This is a source/CI hotfix, not a new app version.

---

## 📌 Additional Context

Failed check: [validate-pr-description](https://github.com/m7xlab/ivdrive/actions/runs/34318452294/job/102359592635?pr=184) — first body used `## Summary` instead of `## 📋 Summary`.