### PR TITLE
fix(collector): capture home charging on CONNECT_CABLE (v1.1.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v1.1.15] - 2026-09-10
+Collector hotfix: parked home charging was missed when Škoda reported `CONNECT_CABLE` instead of `CHARGING`. No schema change. No new UI.
+
+### Fixed
+- **Home charging sessions dropped** (`CONNECT_CABLE`): smart-poll treated only `state == "CHARGING"` as active, so a plugged-in parked car stayed on the 30‑minute interval and `charging_sessions` was never opened. Škoda often never emits `CHARGING` (power stays 0 kW) while SoC still rises — MySkoda still has the history; iVDrive only sees live polls. Collector and analytics now treat plugged-in states (`CHARGING`, `READY_FOR_CHARGING`, `CONNECT_CABLE`, `CHARGING_INTERRUPTED`, `CONSERVING`) as charging. Rebuild **api + collector**. Web unchanged. No Alembic.
+
+### Database
+- Head remains `c5849a2e1b70`. No new migration.
+
 ## [v1.1.14] - 2026-09-08
 Major feature release on top of v1.1.3: six-method Battery SoH v2 (weighted-median combined), trip-gap vampire drain, user charging plans, display locale (ECB FX + metric/UK/US units), CARTO basemap API keys, Nominatim/Photon geo cache, and a Node 24 frontend image. Storage stays km / °C / EUR / kWh; conversion is display-only.
 

--- a/backend/app/services/analytics.py
+++ b/backend/app/services/analytics.py
@@ -23,6 +23,23 @@ from app.services.external_apis import reverse_geocode_country
 
 logger = logging.getLogger(__name__)
 
+# Škoda often never reports state=CHARGING. Home AC shows CONNECT_CABLE with
+# charge_power_kw=0 the whole time while SoC still rises. Smart-poll used to
+# treat that as parked (30 min), so charging_sessions were never opened.
+PLUGGED_IN_STATES = frozenset({
+    "CHARGING",
+    "READY_FOR_CHARGING",
+    "CONNECT_CABLE",
+    "CHARGING_INTERRUPTED",
+    "CONSERVING",
+})
+
+
+def is_plugged_in(state: str | None) -> bool:
+    """True when the vehicle is on a cable / charging, not merely parked."""
+    return bool(state) and state.upper() in PLUGGED_IN_STATES
+
+
 async def process_completed_trips_and_charges(user_vehicle_id: UUID) -> None:
     """
     Runs after telemetry is gathered. 
@@ -143,7 +160,7 @@ async def process_completed_trips_and_charges(user_vehicle_id: UUID) -> None:
 
 
             # --- CHARGING SESSIONS LOGIC ---
-            is_charging = latest_charge and latest_charge.state in ("CHARGING", "READY_FOR_CHARGING")
+            is_charging = is_plugged_in(latest_charge.state if latest_charge else None)
             
             open_charge_res = await session.execute(
                 select(ChargingSession).where(ChargingSession.user_vehicle_id == user_vehicle_id, ChargingSession.session_end.is_(None))

--- a/backend/app/services/collector.py
+++ b/backend/app/services/collector.py
@@ -21,7 +21,7 @@ from app.models.telemetry import (
 from app.models.vehicle import ConnectorSession, UserVehicle
 from app.services.crypto import decrypt_field, encrypt_field
 from app.services.events import CHANNEL_VEHICLE_EVENTS, get_valkey_pubsub_client, get_valkey_client
-from app.services.analytics import process_completed_trips_and_charges
+from app.services.analytics import is_plugged_in, process_completed_trips_and_charges
 from app.services.external_apis import fetch_weather_and_elevation, fetch_nordpool_price
 from app.services.skoda_api import SkodaAPIClient
 from app.services.skoda_auth import SkodaAuthClient
@@ -534,9 +534,12 @@ class DataCollector:
                     if not is_moving:
                         # Not moving — check charging (2nd API call)
                         charging = await _safe(api.get_charging(vin), "charging", user_vehicle_id, cycle_errors)
-                        is_charging = (
-                            charging and charging.status
-                            and charging.status.state == "CHARGING"
+                        # CONNECT_CABLE / READY_FOR_CHARGING must count as active.
+                        # Škoda frequently never emits CHARGING (power stays 0) while SoC rises.
+                        is_charging = bool(
+                            charging
+                            and charging.status
+                            and is_plugged_in(charging.status.state)
                         )
 
                         if not is_charging:

--- a/backend/tests/test_charging_detect.py
+++ b/backend/tests/test_charging_detect.py
@@ -1,0 +1,16 @@
+from app.services.analytics import is_plugged_in
+
+
+def test_plugged_in_includes_connect_cable():
+    assert is_plugged_in("CONNECT_CABLE") is True
+    assert is_plugged_in("charging") is True
+    assert is_plugged_in("READY_FOR_CHARGING") is True
+    assert is_plugged_in("CHARGING_INTERRUPTED") is True
+    assert is_plugged_in("CONSERVING") is True
+
+
+def test_plugged_in_rejects_parked_and_empty():
+    assert is_plugged_in(None) is False
+    assert is_plugged_in("") is False
+    assert is_plugged_in("DISCONNECTED") is False
+    assert is_plugged_in("OFF") is False


### PR DESCRIPTION
## 📋 Summary

Parked home charging was never written to `charging_sessions` when Škoda reported `CONNECT_CABLE` (often with 0 kW) instead of `CHARGING`. Smart-poll stayed on the 30‑minute parked interval; MySkoda still has the history because it reads Škoda’s finished-charge list. Collector and analytics now treat plugged-in states as charging so we keep polling and open a session.

No manual-add UI in this PR. Force-refresh cannot recover a charge that already finished.

**Related Issues:** none to close. Production evidence: SoC 26%→90% and 50%→72% with only `CONNECT_CABLE` rows.

---

## 🧩 Type of Change

- [ ] 🆕 New feature (e.g. new dashboard, API endpoint)
- [x] 🐛 Bug fix
- [x] ⚙️ Backend change (API, collector, database)
- [ ] 🎨 Frontend change (UI, charts, pages)
- [x] 📚 Documentation update
- [ ] 🔧 Configuration / deployment
- [ ] 🚨 Breaking change

---

## ✅ Validation

- [x] Backend runs and tests pass (if applicable)
  - `tests/test_charging_detect.py` (is_plugged_in)
- [ ] Frontend builds (`npm run build` in `frontend/`)
  - N/A — web unchanged
- [x] Manual testing done (if applicable)
  - Production DB: missed sessions were CONNECT_CABLE-only SoC jumps; live CHARGING sessions still written today

---

## 👥 Reviewer Notes

Approve/merge, then tag **v1.1.15** and rebuild **api + collector** (web can stay v1.1.14). No Alembic. Head stays `c5849a2e1b70`.

Plugged-in cars will poll at the active interval (more Škoda calls while left on a cable). That is the intended tradeoff vs missing home sessions.

---

## 📌 Additional Context

v1.1.3 already had `state == "CHARGING"` only. This is not a regression from the v1.1.14 login recut; restarting the collector made the old miss more visible.

